### PR TITLE
Add tailored GitHub issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,111 @@
+name: Bug report / 缺陷报告
+description: Report a reproducible problem in Prayu / 报告可复现的 Prayu 问题
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Prayu. Please search existing issues before filing a new report.
+
+        **Security and privacy:** do not include credentials, API keys, personal data, private prompts, provider payloads, raw tool arguments or output, or unredacted host paths. If the report contains exploitable details or other sensitive material, stop and use the repository's [Security page](https://github.com/Qiyuanqiii/CTF-CyberAgent-Workbench/security) instead of opening a public issue.
+
+  - type: input
+    id: version
+    attributes:
+      label: Prayu version or commit
+      description: Provide a release version, build identifier, or full Git commit SHA.
+      placeholder: "Commit 0123456789abcdef..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      description: Select every interface where you observed the problem.
+      multiple: true
+      options:
+        - CLI
+        - TUI
+        - Web console
+        - Windows Desktop
+        - HTTP API
+        - Go package or internal service
+        - Build, packaging, or CI
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: Include the OS version and architecture when relevant.
+      placeholder: "Windows 11 24H2 (x86-64), Ubuntu 24.04 (x86-64), or macOS 15 (arm64)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: latest_main
+    attributes:
+      label: Reproduces on the latest main branch
+      description: If it is safe and practical, check whether the problem still occurs on the latest main branch.
+      options:
+        - "Yes"
+        - "No"
+        - Not tested
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Give the smallest deterministic sequence that reproduces the problem. Use mock or non-sensitive data where possible.
+      placeholder: |
+        1. Start Prayu with ...
+        2. Create or open ...
+        3. Select ...
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead? Include any bounded, non-sensitive error message.
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Sanitized diagnostics
+      description: Share only the minimum relevant, redacted logs or screenshots. Do not attach a database, credential store, full environment dump, raw provider exchange, prompt, or tool payload.
+      placeholder: "Paste a short redacted excerpt, or write 'None'."
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other non-sensitive detail that helps distinguish this problem from similar reports.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues and did not find an equivalent report.
+          required: true
+        - label: I removed credentials, personal data, private prompts, provider payloads, raw tool arguments/output, and sensitive local paths.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and design discussion / 问答与设计讨论
+    url: https://github.com/Qiyuanqiii/CTF-CyberAgent-Workbench/discussions
+    about: Ask for help or discuss an early idea before opening an actionable issue.
+  - name: Security-sensitive report / 安全敏感报告
+    url: https://github.com/Qiyuanqiii/CTF-CyberAgent-Workbench/security
+    about: Do not disclose credentials, personal data, or exploitable details in a public issue; review the repository Security page first.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -60,7 +60,7 @@ body:
     id: authority_impact
     attributes:
       label: Authority and trust-boundary impact
-      description: State whether this changes file reads/writes, process or Shell execution, network access, browser/CDP, Docker, credentials, approvals, delegation, or persistence. Write "No authority change" if none apply.
+      description: State whether this changes files, process or Shell execution, network, browser/CDP, Docker, credentials, approvals, delegation, or persistence. Write "No authority change" if none apply.
       placeholder: "Capabilities affected, who authorizes them, where Go enforces the boundary, and what remains explicitly unavailable."
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,95 @@
+name: Feature request / 功能建议
+description: Propose a scoped improvement to Prayu / 提议边界清晰的 Prayu 改进
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the user problem first, then the smallest useful outcome. Prayu treats repository content, model output, tool output, Skills, and Analyzer results as untrusted evidence; a feature must not use them to widen runtime authority.
+
+        For general questions or early design discussion, use [GitHub Discussions](https://github.com/Qiyuanqiii/CTF-CyberAgent-Workbench/discussions).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or user need
+      description: Who is affected, what are they trying to accomplish, and what currently blocks them?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Relevant surface
+      description: Select every interface or subsystem the proposal is expected to affect.
+      multiple: true
+      options:
+        - CLI
+        - TUI
+        - Web console
+        - Windows Desktop
+        - HTTP API
+        - Go control plane
+        - Rust or WASI Analyzer
+        - Documentation or contributor workflow
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Proposed outcome
+      description: Describe observable behavior and the smallest useful scope. Implementation ideas are welcome but optional.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List concrete conditions that would demonstrate the feature works, including relevant failure behavior.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: authority_impact
+    attributes:
+      label: Authority and trust-boundary impact
+      description: State whether this changes file reads/writes, process or Shell execution, network access, browser/CDP, Docker, credentials, approvals, delegation, or persistence. Write "No authority change" if none apply.
+      placeholder: "Capabilities affected, who authorizes them, where Go enforces the boundary, and what remains explicitly unavailable."
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: authority_checks
+    attributes:
+      label: Authority-boundary checks
+      description: Confirm these constraints or explain any conflict in the authority-impact section.
+      options:
+        - label: I identified whether this proposal affects file, process, network, browser/CDP, Docker, credential, approval, delegation, or persistence behavior.
+          required: true
+        - label: UI, profile, configuration, model output, repository content, Skill text, or Analyzer output alone must not grant runtime authority.
+          required: true
+        - label: Any privileged action remains behind Go-owned scope, policy, approval, budget, lease, and process gates, or I stated that the proposal adds no privileged action.
+          required: true
+        - label: I considered recovery, auditability, privacy, and fail-closed behavior wherever the proposal changes execution or durable state.
+          required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe workarounds, smaller designs, or reasons existing behavior is insufficient.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission check
+      options:
+        - label: I searched existing issues and discussions for a similar request.
+          required: true


### PR DESCRIPTION
## Summary

- add a focused bug report form for Prayu versions, product surfaces, operating systems, deterministic reproduction, and sanitized diagnostics
- add a feature request form with explicit acceptance criteria and authority/trust-boundary review
- disable blank issues and route questions to Discussions and sensitive reports to the repository Security page

## Why

The repository currently has no structured issue intake. These forms make incoming reports more actionable while reinforcing Prayu's privacy and Go-owned authority boundaries. The change is independently valid against `main` and does not rely on a separate security-policy pull request.

## User and developer impact

Contributors get two concise, task-specific forms instead of an unstructured issue. Maintainers receive the environment and boundary information needed to reproduce bugs and evaluate feature proposals without encouraging disclosure of credentials, private prompts, provider payloads, raw tool data, or sensitive local paths.

## Validation

- Ruby `Psych` parsed all three YAML files successfully
- custom basic Issue Form/config schema checks passed (required keys, supported body types, unique IDs, labels, contact-link shape)
- `git diff --cached --check`
- verified existing `bug` and `enhancement` labels
- verified Discussions is enabled and the repository Security route is the independent sensitive-report entry point

## Audit

- no credentials or runtime data included
- no product behavior, execution permission, schema, API, or persistence changes
- templates explicitly preserve Prayu's scope, policy, approval, budget, lease, and process-gate model
