### PR TITLE
ci: pin GitHub Actions by commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     name: Go control plane
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -27,7 +27,7 @@ jobs:
         run: go test -count=1 ./internal/analyzer -run 'Test(AnalyzerProtocol|ArchiveInventory)SharedGoldenVectors'
       - run: go test -timeout 20m -count=1 ./...
       - run: go vet ./...
-      - uses: golang/govulncheck-action@v1
+      - uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1
         with:
           cache: false
           go-package: ./...
@@ -40,8 +40,8 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: npm
@@ -69,8 +69,8 @@ jobs:
       run:
         working-directory: analyzers
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -100,12 +100,12 @@ jobs:
     name: Windows Desktop shell
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
## Summary

- Pin every third-party action used by the CI workflow to an immutable 40-character commit SHA.
- Retain the reviewed major-version tag as an inline comment so future updates remain understandable.

## Why

GitHub Action major-version tags are mutable. Resolving the exact reviewed revisions in the repository prevents an upstream tag move from changing the code executed with the CI job's `contents: read` token and checked-out source.

## Impact

CI behavior and action major versions are unchanged. Dependency updates must now intentionally replace both the commit SHA and its version comment.

## Validation

- YAML parse with Ruby/Psych
- `actionlint` v1.7.12
- custom check proving all 10 direct `uses:` references contain a lowercase 40-character SHA and a version comment
- `git diff --check`

## Audit

- No workflow permissions, triggers, commands, dependencies, product code, or runtime authority changed.
- No credentials or local runtime data are included.