### PR TITLE
fix: refresh run details after durable events

### DIFF
--- a/web/src/components/run-workspace.tsx
+++ b/web/src/components/run-workspace.tsx
@@ -60,6 +60,7 @@ import type {
   WorkItemView,
 } from "../api/types";
 import { usePagedResource } from "../hooks/use-paged-resource";
+import { useRunDetailEventRefresh } from "../hooks/use-run-detail-event-refresh";
 import { useRunEventStream } from "../hooks/use-run-event-stream";
 import { usePublicModelStream } from "../hooks/use-public-model-stream";
 import { formatBytes, formatDate, formatNumber, shortID } from "../lib/format";
@@ -161,6 +162,7 @@ export function RunWorkspace({ client, runID, onOpenPlugins }: {
     enabled: Boolean(runID) && tab === "activity",
   });
   const latestStreamFrame = stream.frames.at(-1);
+  useRunDetailEventRefresh(runID, latestStreamFrame);
   const journeyHandoffQuery = useQuery({
     queryKey: ["run", runID, "code-handoff"],
     queryFn: ({ signal }) => client.codeHandoff(runID, signal),

--- a/web/src/hooks/use-run-detail-event-refresh.test.tsx
+++ b/web/src/hooks/use-run-detail-event-refresh.test.tsx
@@ -1,0 +1,67 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { EventView, RunEventStreamView } from "../api/types";
+import { useRunDetailEventRefresh } from "./use-run-detail-event-refresh";
+
+describe("useRunDetailEventRefresh", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("refreshes the exact authoritative Run detail after a durable event", async () => {
+    const queryClient = new QueryClient();
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    renderHook(() => useRunDetailEventRefresh("run-1", frame(1, "run.status_changed")),
+      { wrapper });
+
+    await act(async () => vi.advanceTimersByTime(100));
+
+    expect(invalidate).toHaveBeenCalledTimes(1);
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["run", "run-1"], exact: true });
+  });
+
+  it("coalesces event bursts and ignores transient model deltas", async () => {
+    const queryClient = new QueryClient();
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    const hook = renderHook(({ latest }) => useRunDetailEventRefresh("run-1", latest), {
+      initialProps: { latest: frame(1, "run.status_changed") }, wrapper,
+    });
+
+    hook.rerender({ latest: frame(2, "execution.lease_acquired") });
+    hook.rerender({ latest: frame(3, "model.delta") });
+    await act(async () => vi.advanceTimersByTime(100));
+    expect(invalidate).toHaveBeenCalledTimes(1);
+
+    hook.rerender({ latest: frame(4, "model.delta") });
+    await act(async () => vi.advanceTimersByTime(200));
+    expect(invalidate).toHaveBeenCalledTimes(1);
+  });
+});
+
+function frame(sequence: number, type: string): RunEventStreamView {
+  return {
+    version: "run-events.v1",
+    request_id: `request-${sequence}`,
+    run_id: "run-1",
+    sequence,
+    cursor: `cursor-${sequence}`,
+    event: event(sequence, type),
+  };
+}
+
+function event(sequence: number, type: string): EventView {
+  return {
+    version: "v1",
+    event_id: `event-${sequence}`,
+    mission_id: "mission-1",
+    run_id: "run-1",
+    sequence,
+    type,
+    source: "test",
+    payload: {},
+    created_at: "2026-08-12T00:00:00Z",
+  };
+}

--- a/web/src/hooks/use-run-detail-event-refresh.ts
+++ b/web/src/hooks/use-run-detail-event-refresh.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { RunEventStreamView } from "../api/types";
+
+const runDetailRefreshDelayMs = 100;
+
+export function useRunDetailEventRefresh(
+  runID: string,
+  latestFrame: RunEventStreamView | undefined,
+): void {
+  const queryClient = useQueryClient();
+  const refreshTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!runID || !latestFrame || latestFrame.event.type === "model.delta" ||
+      refreshTimer.current !== null) {
+      return;
+    }
+    refreshTimer.current = window.setTimeout(() => {
+      refreshTimer.current = null;
+      void queryClient.invalidateQueries({ queryKey: ["run", runID], exact: true });
+    }, runDetailRefreshDelayMs);
+  }, [latestFrame, queryClient, runID]);
+
+  useEffect(() => () => {
+    if (refreshTimer.current !== null) {
+      window.clearTimeout(refreshTimer.current);
+      refreshTimer.current = null;
+    }
+  }, [runID]);
+}


### PR DESCRIPTION
## What

- refresh the exact authoritative Run detail query after durable Run events
- coalesce event bursts and exclude transient `model.delta` frames from detail refetches
- add focused hook coverage for refresh, burst coalescing, and delta exclusion

## Why

The live event stream updated the Activity timeline but did not refresh `GET /runs/{run_id}`. A lifecycle change made by the CLI, wake worker, or another UI could therefore leave the header, composer, and control buttons on a stale Run status indefinitely because focus refetching is disabled.

## Impact

Run-scoped controls converge on server-authoritative status after streamed or Desktop-polled durable events. The bounded delay avoids one detail request per event burst, and high-frequency model deltas remain excluded.

## Checks

- `npm test` (56 files, 213 tests)
- `npm run typecheck`
- `npm run check:api`
- `npm run build`
- `npm audit --audit-level=moderate`
- `git diff --check`

All checks ran with Node 24.19.0. Vite retains the repository's existing large-chunk warning.