### PR TITLE
test: normalize macOS temporary paths

### DIFF
--- a/internal/application/sandbox_manifest_test.go
+++ b/internal/application/sandbox_manifest_test.go
@@ -344,7 +344,10 @@ func newSandboxManifestTestRuntimeWithBudget(t *testing.T, ctx context.Context,
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = st.Close() })
-	root := t.TempDir()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := st.SaveWorkspace(ctx, store.WorkspaceRecord{
 		ID: "ws-sandbox", Name: "sandbox", RootPath: root,
 	}); err != nil {

--- a/internal/browserruntime/acceptance_test.go
+++ b/internal/browserruntime/acceptance_test.go
@@ -147,7 +147,7 @@ func browserIdentityFixture(t *testing.T, product BrowserProduct,
 	channel BrowserChannel,
 ) BrowserExecutableIdentity {
 	t.Helper()
-	root := t.TempDir()
+	root := directTestPath(t, t.TempDir())
 	spec := knownSpec(t, DiscoveryRootProgramFiles, product, channel)
 	path := filepath.Join(append([]string{root}, spec.Components...)...)
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {

--- a/internal/browserruntime/executable_test.go
+++ b/internal/browserruntime/executable_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestBrowserExecutableDiscoveryBindsFixedPEBytesWithoutPATHOrLaunch(t *testing.T) {
-	root := t.TempDir()
+	root := directTestPath(t, t.TempDir())
 	relative := filepath.Join("Google", "Chrome", "Application", "chrome.exe")
 	path := filepath.Join(root, relative)
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
@@ -60,7 +60,7 @@ func TestBrowserExecutableDiscoveryBindsFixedPEBytesWithoutPATHOrLaunch(t *testi
 }
 
 func TestBrowserExecutableDiscoveryRejectsRegistryEscapeAndUnsafeCandidate(t *testing.T) {
-	root := t.TempDir()
+	root := directTestPath(t, t.TempDir())
 	escape := browserExecutableSpec{
 		RootID: DiscoveryRootProgramFiles, Product: BrowserProductChrome,
 		Channel: BrowserChannelStable, Vendor: "Google",
@@ -86,7 +86,7 @@ func TestBrowserExecutableDiscoveryRejectsRegistryEscapeAndUnsafeCandidate(t *te
 }
 
 func TestBrowserExecutableIdentityRejectsTamperingAndByteDrift(t *testing.T) {
-	root := t.TempDir()
+	root := directTestPath(t, t.TempDir())
 	spec := knownSpec(t, DiscoveryRootProgramFiles, BrowserProductEdge,
 		BrowserChannelStable)
 	path := filepath.Join(append([]string{root}, spec.Components...)...)
@@ -131,7 +131,7 @@ func TestBrowserExecutableIdentityRejectsTamperingAndByteDrift(t *testing.T) {
 }
 
 func TestBrowserExecutableDiscoverySkipsMissingCandidatesAndDeduplicatesRoots(t *testing.T) {
-	root := t.TempDir()
+	root := directTestPath(t, t.TempDir())
 	spec := knownSpec(t, DiscoveryRootProgramFiles, BrowserProductChromium,
 		BrowserChannelStable)
 	identities, err := discoverBrowserExecutables([]DiscoveryRoot{
@@ -203,4 +203,13 @@ func minimalPEImage(t *testing.T, arch string) []byte {
 	binary.LittleEndian.PutUint16(raw[0x86:0x88], 1)
 	binary.LittleEndian.PutUint16(raw[0x96:0x98], 0x0002)
 	return raw
+}
+
+func directTestPath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
 }

--- a/internal/browserruntime/launch_lifecycle_test.go
+++ b/internal/browserruntime/launch_lifecycle_test.go
@@ -140,7 +140,7 @@ func browserLaunchFixture(t *testing.T) (SessionPlan, BrowserExecutableIdentity,
 	if err != nil {
 		t.Fatal(err)
 	}
-	root := t.TempDir()
+	root := directTestPath(t, t.TempDir())
 	spec := knownSpec(t, DiscoveryRootProgramFiles, BrowserProductChrome,
 		BrowserChannelStable)
 	path := filepath.Join(append([]string{root}, spec.Components...)...)
@@ -168,7 +168,7 @@ func browserLaunchFixture(t *testing.T) (SessionPlan, BrowserExecutableIdentity,
 	if err != nil {
 		t.Fatal(err)
 	}
-	profileRoot := filepath.Join(t.TempDir(), ProfileRuntimeRootName)
+	profileRoot := filepath.Join(directTestPath(t, t.TempDir()), ProfileRuntimeRootName)
 	ownership, err := BuildProfileOwnershipPlan(session, identity, profileRoot)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/browserruntime/production_runtime_test.go
+++ b/internal/browserruntime/production_runtime_test.go
@@ -42,7 +42,7 @@ func newLoopbackBrowserRuntimeFacts(t *testing.T) browserRuntimeFacts {
 		t.Fatal(err)
 	}
 	ownership, err := BuildProfileOwnershipPlan(session, identity,
-		filepath.Join(t.TempDir(), ProfileRuntimeRootName))
+		filepath.Join(directTestPath(t, t.TempDir()), ProfileRuntimeRootName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestSafeWebAuthorizationRequiresRestrictedLiteralLoopbackAndRuntimeGates(t 
 		t.Fatal(err)
 	}
 	publicOwnership, err := BuildProfileOwnershipPlan(publicSession, facts.identity,
-		filepath.Join(t.TempDir(), ProfileRuntimeRootName))
+		filepath.Join(directTestPath(t, t.TempDir()), ProfileRuntimeRootName))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/browserruntime/profile_lifecycle_test.go
+++ b/internal/browserruntime/profile_lifecycle_test.go
@@ -230,7 +230,7 @@ func profileLifecycleFixture(t *testing.T) (SessionPlan, BrowserExecutableIdenti
 	ProfileOwnershipPlan, string,
 ) {
 	t.Helper()
-	installRoot := t.TempDir()
+	installRoot := directTestPath(t, t.TempDir())
 	spec := knownSpec(t, DiscoveryRootProgramFiles, BrowserProductEdge, BrowserChannelStable)
 	executablePath := filepath.Join(append([]string{installRoot}, spec.Components...)...)
 	if err := os.MkdirAll(filepath.Dir(executablePath), 0o700); err != nil {
@@ -253,7 +253,7 @@ func profileLifecycleFixture(t *testing.T) (SessionPlan, BrowserExecutableIdenti
 	if err != nil {
 		t.Fatal(err)
 	}
-	runtimeRoot := filepath.Join(t.TempDir(), ProfileRuntimeRootName)
+	runtimeRoot := filepath.Join(directTestPath(t, t.TempDir()), ProfileRuntimeRootName)
 	ownership, err := BuildProfileOwnershipPlan(session, identities[0], runtimeRoot)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/tools/file_test.go
+++ b/internal/tools/file_test.go
@@ -171,7 +171,10 @@ func TestReadFileToolRedactsSecrets(t *testing.T) {
 }
 
 func TestWorkspaceFSResolveForWriteScopesExistingAndNewFiles(t *testing.T) {
-	parent := t.TempDir()
+	parent, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	root := filepath.Join(parent, "workspace")
 	if err := os.MkdirAll(filepath.Join(root, "scripts"), 0o755); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## What

- resolve security-sensitive test fixture roots before exercising no-indirection path checks
- cover browser discovery/profile fixtures, sandbox Workspace fixtures, and Workspace write resolution
- keep production path validation unchanged and fail closed

## Why

On macOS, `testing.T.TempDir()` may return `/var/...` while the filesystem resolves it through the system `/var` to `/private/var` alias. Tests that intentionally reject indirect paths then reject their own trusted fixture roots. This caused the full local Go suite to fail consistently across browser runtime, sandbox, and Workspace path tests despite the production boundary behaving as designed.

## Impact

The security tests now supply canonical direct fixture paths on macOS without weakening any production validation. Linux and Windows retain the same effective test paths.

## Checks

- `go mod verify`
- `go test -timeout 20m -count=1 ./...`
- `go vet ./...`
- focused affected packages
- 20 repetitions of affected browser/sandbox/Workspace cases
- `git diff --check`

All Go checks used Go 1.25.12.