### PR TITLE
fix: reject unknown Run execution statuses

### DIFF
--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -531,6 +531,20 @@ describe("CyberAgentClient", () => {
     }, "web-run-execution-operation-0002")).rejects.toThrow("invalid");
   });
 
+  it("rejects a Run execution response with an unknown Run status", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      version: "api.v1", request_id: "req-execute-status-forged",
+      data: { ...runExecutionData, run_status: "arbitrary" },
+    }), { status: 202, headers: { "Content-Type": "application/json" } })));
+    const client = new CyberAgentClient("read-secret", "/api/v1", "control-secret", {
+      runExecutionEnabled: true,
+    });
+
+    await expect(client.executeRun("run-1", {
+      version: "run_execution_handoff.v1", max_steps: 2,
+    }, "web-run-execution-status-0001")).rejects.toThrow("invalid");
+  });
+
   it("accepts an exact lifecycle replay after the Run has advanced", async () => {
     const delayedReplay = {
       ...runLifecycleData, replayed: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -470,7 +470,7 @@ function parseRunExecutionControl(value: unknown, expectedRunID: string,
       value.cancelled_count !== value.selected_count ||
     !safePositiveInteger(value.completion_event_sequence) ||
     (value.status !== "completed" && value.status !== "failed") ||
-    typeof value.run_status !== "string" || typeof value.stop_reason !== "string" ||
+    !isRunStatus(value.run_status) || typeof value.stop_reason !== "string" ||
     value.stop_reason.length === 0 || value.stop_reason.length > 64 ||
     typeof value.replayed !== "boolean" || typeof value.execution_started !== "boolean" ||
     typeof value.model_called !== "boolean" || typeof value.tool_called !== "boolean" ||


### PR DESCRIPTION
## What

- validate `run_status` against the closed Run status enum in execution responses
- add a forged-response regression for an arbitrary status string

## Why

The generated OpenAPI contract exposes `run_status` as a closed enum, but the runtime parser accepted any string. A malformed or drifted server response could therefore enter UI state instead of failing as an invalid response.

## Impact

The client now fails closed when execution response status semantics drift from the Go/OpenAPI contract. Valid statuses are unchanged.

## Checks

- `npm test -- --run src/api/client.test.ts` (66 tests)
- `npm test` (55 files, 212 tests)
- `npm run typecheck`
- `npm run check:api`
- `npm run build`
- `npm audit --audit-level=moderate`
- `git diff --check`

All checks ran with Node 24.19.0. Vite retains the existing large-chunk warning.