### PR TITLE
ci: configure dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,66 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    groups:
+      go-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:15"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    groups:
+      web-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: cargo
+    directory: /analyzers
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:30"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    groups:
+      rust-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:45"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## What

- monitor Go modules at `/`
- monitor npm dependencies in `/web`
- monitor Cargo dependencies in `/analyzers`
- monitor GitHub Actions in `/.github/workflows`
- group minor and patch updates per ecosystem on a staggered weekly schedule

## Why

The repository has lockfiles across three language ecosystems plus workflow actions, but no automated version-update coverage. This leaves security and maintenance releases dependent on manual discovery.

## Impact

Dependabot can open bounded, ecosystem-specific update PRs after this reaches the default branch. Major updates remain separate for deliberate review. Repository-level Dependabot alerts and security updates still need to be enabled in Settings; this file does not claim to enable them.

## Checks

- parsed YAML and validated all required ecosystems, directories, schedules, and groups
- cross-checked syntax against the GitHub Dependabot options reference
- `git diff --check`