### PR TITLE
fix: support every configured model harness

### DIFF
--- a/web/src/components/model-availability-dialog.test.tsx
+++ b/web/src/components/model-availability-dialog.test.tsx
@@ -75,9 +75,10 @@ describe("ModelAvailabilityDialog", () => {
     render(<QueryClientProvider client={queryClient}>
       <ModelAvailabilityDialog client={client} open onClose={vi.fn()} />
     </QueryClientProvider>);
-    await user.click(await screen.findByRole("button", { name: "Diagnose mock" }));
+    expect(await screen.findByRole("button", { name: "Diagnose mock/mock-code" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Diagnose mock/mock-fast" }));
     await waitFor(() => expect(diagnoseProvider).toHaveBeenCalledWith({
-      version: "provider_diagnostic.v1", provider: "mock", model: "mock-code",
+      version: "provider_diagnostic.v1", provider: "mock", model: "mock-fast",
       confirm_diagnostic: true,
     }));
     expect(await screen.findByText("reachable")).toBeInTheDocument();
@@ -92,10 +93,10 @@ describe("ModelAvailabilityDialog", () => {
     const user = userEvent.setup();
     const qualifyModelHarness = vi.fn().mockResolvedValue({
       protocol_version: "model_harness_qualification.v1", provider: "mimo",
-      model: "model", status: "qualified", outcome: "success", retryable: false,
+      model: "model-secondary", status: "qualified", outcome: "success", retryable: false,
       network_request_attempted: true, model_calls: 2, synthetic_tool_calls: 1,
       tool_executed: false, response_content_returned: false, duration_ms: 8,
-      harness: { ...mockHarness("model"), transport_protocol: "anthropic_messages",
+      harness: { ...mockHarness("model-secondary"), transport_protocol: "anthropic_messages",
         json_strategy: "prompt", qualification_status: "verified",
         qualified_at: "2026-07-25T00:00:00Z", expires_at: "2026-08-01T00:00:00Z" },
     });
@@ -104,9 +105,10 @@ describe("ModelAvailabilityDialog", () => {
       modelAvailability: vi.fn().mockResolvedValue({
         protocol_version: "model_availability.v2", generation: 1,
         providers: [{ name: "mimo", kind: "anthropic_compatible", status: "available",
-          models: ["model"], credential_source: "system", network_required: true,
-          configuration_error: false, harnesses: [requiredHarness("model")] }],
-        routes: [{ name: "code", provider: "mimo", model: "model", available: true,
+          models: ["model-primary", "model-secondary"], credential_source: "system",
+          network_required: true, configuration_error: false,
+          harnesses: [mockHarness("model-primary"), requiredHarness("model-secondary")] }],
+        routes: [{ name: "code", provider: "mimo", model: "model-secondary", available: true,
           harness_ready: false }],
       }),
     } as unknown as CyberAgentClient;
@@ -116,9 +118,11 @@ describe("ModelAvailabilityDialog", () => {
     render(<QueryClientProvider client={queryClient}>
       <ModelAvailabilityDialog client={client} open onClose={vi.fn()} />
     </QueryClientProvider>);
-    await user.click(await screen.findByRole("button", { name: "Qualify mimo Harness" }));
+    expect(await screen.findByRole("button", { name: "Qualify mimo/model-primary Harness" }))
+      .toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Qualify mimo/model-secondary Harness" }));
     await waitFor(() => expect(qualifyModelHarness).toHaveBeenCalledWith({
-      version: "model_harness_qualification.v1", provider: "mimo", model: "model",
+      version: "model_harness_qualification.v1", provider: "mimo", model: "model-secondary",
       confirm_qualification: true,
     }));
     expect(await screen.findByText("2 model calls")).toBeInTheDocument();

--- a/web/src/components/model-availability-dialog.tsx
+++ b/web/src/components/model-availability-dialog.tsx
@@ -128,47 +128,51 @@ function ModelAvailabilitySurface({ client, open, onClose, presentation }: {
               <section className="model-availability-section">
                 <h3><Cpu aria-hidden="true" size={14} />{t("提供商", "Provider")}</h3>
                 <div className="model-provider-list">
-                  {query.data.providers.map((provider) => {
-                    const harness = provider.harnesses[0];
-                    return <div className="model-provider-row" key={provider.name}>
+                  {query.data.providers.flatMap((provider) =>
+                    (provider.models.length > 0 ? provider.models : [""]).map((model) => {
+                    const harness = provider.harnesses.find((candidate) => candidate.model === model);
+                    const modelReference = `${provider.name}/${model}`;
+                    return <div className="model-provider-row" key={modelReference}>
                       <div><strong>{provider.name}</strong><small>{provider.kind}</small></div>
-                      <span>{provider.models.join(", ") || t("未配置模型", "No configured model")}</span>
+                      <span>{model || t("未配置模型", "No configured model")}</span>
                       <span>{harness
                         ? `${harness.transport_protocol} · JSON ${harness.json_strategy}`
                         : provider.credential_source}</span>
                       <StatusBadge status={provider.status} />
                       {harness && <StatusBadge status={harness.qualification_status} />}
                       {client.hasModelControl && provider.status === "available" &&
-                        provider.models[0] && (
+                        model && (
                           <>
-                            <button aria-label={t(`诊断 ${provider.name}`, `Diagnose ${provider.name}`)} className="icon-button"
+                            <button aria-label={t(`诊断 ${modelReference}`, `Diagnose ${modelReference}`)} className="icon-button"
                               disabled={diagnosticMutation.isPending ||
                                 qualificationMutation.isPending}
                               onClick={() => diagnosticMutation.mutate({ provider: provider.name,
-                                model: provider.models[0]! })}
+                                model })}
                               title={t("运行单次连接诊断", "Run one-call connectivity diagnostic")} type="button">
                               {diagnosticMutation.isPending &&
-                                diagnosticMutation.variables?.provider === provider.name
+                                diagnosticMutation.variables?.provider === provider.name &&
+                                diagnosticMutation.variables.model === model
                                 ? <LoaderCircle aria-hidden="true" className="spin" size={15} />
                                 : <Activity aria-hidden="true" size={15} />}
                             </button>
-                            <button aria-label={t(`验证 ${provider.name} Harness`, `Qualify ${provider.name} Harness`)}
+                            <button aria-label={t(`验证 ${modelReference} Harness`, `Qualify ${modelReference} Harness`)}
                               className="icon-button"
                               disabled={diagnosticMutation.isPending ||
                                 qualificationMutation.isPending || harness?.root_eligible === true}
                               onClick={() => qualificationMutation.mutate({
-                                provider: provider.name, model: provider.models[0]!,
+                                provider: provider.name, model,
                               })}
                               title={t("运行两次调用的 Harness 合成验证", "Run two-call synthetic Harness qualification")} type="button">
                               {qualificationMutation.isPending &&
-                                qualificationMutation.variables?.provider === provider.name
+                                qualificationMutation.variables?.provider === provider.name &&
+                                qualificationMutation.variables.model === model
                                 ? <LoaderCircle aria-hidden="true" className="spin" size={15} />
                                 : <ShieldCheck aria-hidden="true" size={15} />}
                             </button>
                           </>
                         )}
-                    </div>
-                  })}
+                    </div>;
+                  }))}
                 </div>
                 {diagnostic && <div className="model-diagnostic-result" role="status">
                   <span>{diagnostic.provider}/{diagnostic.model}</span>


### PR DESCRIPTION
## What

- render one availability row per configured Provider model
- bind Harness status by model name instead of array position
- diagnose and qualify the exact selected model
- bind loading and disabled states to the exact Provider/model operation

## Why

The API guarantees a one-to-one model/Harness set, but the UI always used `models[0]` and `harnesses[0]`. A second routed model could be selected while remaining impossible to diagnose or qualify, and the status shown could belong to another model.

## Impact

Multi-model Providers expose accurate per-model status and controls. Single-model behavior is unchanged; no API changes.

## Checks

- `npm test` (55 files, 211 tests)
- focused multi-model diagnostic and qualification coverage
- `npm run typecheck`
- `npm run check:api`
- `npm run build`
- `npm audit --audit-level=high`
- `git diff --check`