### PR TITLE
ci: enforce dependency integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
           go-version-file: go.mod
           cache: true
       - run: go mod verify
+      - name: Verify Go module graph is tidy
+        run: go mod tidy -diff
       - name: Verify Go analyzer compatibility vectors
         run: go test -count=1 ./internal/analyzer -run 'Test(AnalyzerProtocol|ArchiveInventory)SharedGoldenVectors'
       - run: go test -timeout 20m -count=1 ./...
@@ -79,6 +81,24 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo test --locked
       - run: cargo clippy --locked --all-targets -- -D warnings
+      - name: Audit locked Rust dependencies
+        env:
+          CARGO_AUDIT_VERSION: 0.22.2
+          CARGO_AUDIT_SHA256: ab28a1bdb54db4d5d8ad5981cf1f959410370b3d28250dbd35f6a44248620e39
+        run: |
+          archive="$RUNNER_TEMP/cargo-audit.tgz"
+          audit_root="$RUNNER_TEMP/cargo-audit"
+          advisory_db="$RUNNER_TEMP/rustsec-advisory-db"
+          curl --fail --location --retry 3 --retry-all-errors \
+            --output "$archive" \
+            "https://github.com/RustSec/rustsec/releases/download/cargo-audit/v${CARGO_AUDIT_VERSION}/cargo-audit-x86_64-unknown-linux-gnu-v${CARGO_AUDIT_VERSION}.tgz"
+          echo "${CARGO_AUDIT_SHA256}  ${archive}" | sha256sum --check
+          mkdir -p "$audit_root"
+          tar --extract --gzip --file "$archive" --directory "$audit_root"
+          git clone --depth 1 https://github.com/RustSec/advisory-db.git "$advisory_db"
+          git -C "$advisory_db" log -1 --format='RustSec advisory DB: %H (%cI)'
+          "$audit_root/cargo-audit-x86_64-unknown-linux-gnu-v${CARGO_AUDIT_VERSION}/cargo-audit" \
+            audit --no-fetch --no-yanked --db "$advisory_db" --file Cargo.lock
       - name: Build deterministic Rust fixture
         run: cargo build --locked --bin cyberagent-analyzer-fixture
       - name: Build embedded WASI analyzer fixture


### PR DESCRIPTION
## What

- fail the Go job when `go.mod` or `go.sum` is not tidy
- scan `analyzers/Cargo.lock` against the current RustSec advisory database
- use the official `cargo-audit 0.22.2` Linux release and verify its publisher-provided SHA-256 before execution
- keep CI permissions read-only and avoid Actions that require check/issue write access

## Why

CI verified downloaded Go modules and ran Rust tests, but it did not reject a stale Go module graph or scan Rust dependencies for known vulnerabilities. The repository release notes describe both as gates, yet ordinary PRs could bypass them.

## Impact

Dependency drift and RustSec findings now fail the existing language jobs. Yanked-crate lookup is intentionally disabled because it requires a mutable crates.io index and is maintenance rather than vulnerability detection; version updates are covered separately by Dependabot.

## Checks

- `go mod tidy -diff` (no drift)
- `cargo-audit 0.22.2` against 1,216 RustSec advisories / 42 locked crates (0 findings)
- verified cargo-audit version and official release SHA-256 metadata
- `actionlint -verbose .github/workflows/ci.yml`
- YAML parse
- `git diff --check`