### PR TITLE
fix: contain focus in modal dialogs

### DIFF
--- a/web/src/components/command-palette.test.tsx
+++ b/web/src/components/command-palette.test.tsx
@@ -12,6 +12,8 @@ describe("CommandPalette", () => {
       { id: "refresh", label: "Refresh Run data", group: "Data", run: refresh },
     ]} />);
 
+    const opener = screen.getByRole("button", { name: "Open command palette" });
+    opener.focus();
     fireEvent.keyDown(window, { ctrlKey: true, key: "k" });
     expect(await screen.findByRole("dialog", { name: "Command palette" })).toBeInTheDocument();
     const input = screen.getByRole("searchbox", { name: "Find a command" });
@@ -22,5 +24,6 @@ describe("CommandPalette", () => {
     expect(openFiles).toHaveBeenCalledTimes(1);
     expect(refresh).not.toHaveBeenCalled();
     expect(screen.queryByRole("dialog", { name: "Command palette" })).not.toBeInTheDocument();
+    expect(opener).toHaveFocus();
   });
 });

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { Command as CommandIcon, Search, X } from "lucide-react";
 import { useLocale } from "../lib/locale";
+import { useModalFocusTrap } from "../hooks/use-modal-focus-trap";
 
 export interface CommandPaletteCommand {
   id: string;
@@ -16,6 +17,7 @@ export function CommandPalette({ commands }: { commands: CommandPaletteCommand[]
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useModalFocusTrap<HTMLElement>(open, () => setOpen(false), false, inputRef);
   const filtered = useMemo(() => {
     const needle = query.trim().toLocaleLowerCase();
     if (!needle) return commands;
@@ -38,7 +40,6 @@ export function CommandPalette({ commands }: { commands: CommandPaletteCommand[]
     if (open) {
       setQuery("");
       setSelected(0);
-      globalThis.requestAnimationFrame(() => inputRef.current?.focus());
     }
   }, [open]);
 
@@ -76,7 +77,7 @@ export function CommandPalette({ commands }: { commands: CommandPaletteCommand[]
       if (event.currentTarget === event.target) setOpen(false);
     }}>
       <section aria-label={t("命令面板", "Command palette")} aria-modal="true" className="command-palette"
-        role="dialog">
+        ref={dialogRef} role="dialog" tabIndex={-1}>
         <header>
           <Search aria-hidden="true" size={17} />
           <input aria-activedescendant={filtered[selected] ? `command-${filtered[selected].id}` : undefined}

--- a/web/src/components/desktop-skill-preview.tsx
+++ b/web/src/components/desktop-skill-preview.tsx
@@ -10,6 +10,7 @@ import {
 import { formatBytes, formatNumber } from "../lib/format";
 import { useLocale } from "../lib/locale";
 import { OperationReceipt } from "./operation-receipt";
+import { useModalFocusTrap } from "../hooks/use-modal-focus-trap";
 
 export function DesktopSkillPreviewDialog({ open, onClose, installationEnabled = false }: {
   open: boolean;
@@ -24,6 +25,7 @@ export function DesktopSkillPreviewDialog({ open, onClose, installationEnabled =
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const operationKey = useRef("");
+  const dialogRef = useModalFocusTrap<HTMLElement>(open, onClose, loading);
 
   useEffect(() => {
     if (!open) {
@@ -32,16 +34,8 @@ export function DesktopSkillPreviewDialog({ open, onClose, installationEnabled =
       setConfirmed(false);
       setError("");
       setLoading(false);
-      return;
     }
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && !loading) {
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [loading, onClose, open]);
+  }, [open]);
 
   if (!open) {
     return null;
@@ -83,7 +77,8 @@ export function DesktopSkillPreviewDialog({ open, onClose, installationEnabled =
 
   return (
     <div className="desktop-dialog-backdrop" role="presentation">
-      <section aria-labelledby="desktop-skill-title" aria-modal="true" className="desktop-dialog" role="dialog">
+      <section aria-labelledby="desktop-skill-title" aria-modal="true" className="desktop-dialog"
+        ref={dialogRef} role="dialog" tabIndex={-1}>
         <header>
           <div>
             <span className="dialog-icon"><FileArchive aria-hidden="true" size={18} /></span>

--- a/web/src/components/model-availability-dialog.tsx
+++ b/web/src/components/model-availability-dialog.tsx
@@ -5,6 +5,7 @@ import type { CyberAgentClient } from "../api/client";
 import type { ModelHarnessQualificationView, ProviderDiagnosticView } from "../api/types";
 import { ErrorState, LoadingState, StatusBadge } from "./common";
 import { useLocale } from "../lib/locale";
+import { useModalFocusTrap } from "../hooks/use-modal-focus-trap";
 
 export function ModelAvailabilityDialog({ client, open, onClose }: {
   client: CyberAgentClient;
@@ -36,6 +37,7 @@ function ModelAvailabilitySurface({ client, open, onClose, presentation }: {
   const [credentialRestart, setCredentialRestart] = useState(false);
   const [credentialGeneration, setCredentialGeneration] = useState<number | null>(null);
   const credentialInputs = useRef(new Map<string, HTMLInputElement>());
+  const dialogRef = useModalFocusTrap<HTMLElement>(open && presentation === "dialog", onClose);
   const query = useQuery({
     queryKey: ["models", "availability"],
     queryFn: ({ signal }) => client.modelAvailability(signal),
@@ -108,7 +110,8 @@ function ModelAvailabilitySurface({ client, open, onClose, presentation }: {
         aria-modal={presentation === "dialog" ? "true" : undefined}
         className={presentation === "dialog"
           ? "desktop-dialog model-availability-dialog" : "model-control-workspace"}
-        role={presentation === "dialog" ? "dialog" : "region"}>
+        ref={dialogRef} role={presentation === "dialog" ? "dialog" : "region"}
+        tabIndex={presentation === "dialog" ? -1 : undefined}>
         <header>
           <div>
             <span className="dialog-icon"><Cpu aria-hidden="true" size={18} /></span>

--- a/web/src/components/resource-sidebar.tsx
+++ b/web/src/components/resource-sidebar.tsx
@@ -24,6 +24,7 @@ import { useLocale } from "../lib/locale";
 import { useConnectionStore } from "../state/connection";
 import { ErrorState, LoadMoreButton, LoadingState } from "./common";
 import { PrayuBrand } from "./prayu-brand";
+import { useModalFocusTrap } from "../hooks/use-modal-focus-trap";
 
 export type WorkbenchSection =
   | "conversation"
@@ -98,6 +99,8 @@ export function ResourceSidebar({ client, activeSection, onCreateRun, onNavigate
       void queryClient.invalidateQueries({ queryKey: ["session", result.session_id] });
     },
   });
+  const archiveDialogRef = useModalFocusTrap<HTMLElement>(Boolean(archiveCandidate),
+    () => setArchiveCandidate(null), archiveMutation.isPending);
 
   useEffect(() => {
     if (kind === "run" && !runsQuery.isLoading && !runsQuery.isFetching &&
@@ -227,7 +230,8 @@ export function ResourceSidebar({ client, activeSection, onCreateRun, onNavigate
 
       {archiveCandidate && <div className="desktop-dialog-backdrop" role="presentation">
         <section aria-labelledby="archive-session-title" aria-modal="true"
-          className="desktop-dialog archive-session-dialog" role="dialog">
+          className="desktop-dialog archive-session-dialog" ref={archiveDialogRef}
+          role="dialog" tabIndex={-1}>
           <header>
             <div><span className="dialog-icon"><Trash2 aria-hidden="true" size={17} /></span>
               <div><h2 id="archive-session-title">{t("删除对话", "Delete conversation")}</h2>

--- a/web/src/components/run-creation-dialog.tsx
+++ b/web/src/components/run-creation-dialog.tsx
@@ -9,6 +9,7 @@ import type {
 } from "../api/types";
 import { useConnectionStore } from "../state/connection";
 import { useLocale } from "../lib/locale";
+import { useModalFocusTrap } from "../hooks/use-modal-focus-trap";
 
 const profiles: Array<NonNullable<RunCreationControlRequestView["profile"]>> = ["code", "review", "learn", "script"];
 const surfaces: Array<NonNullable<RunCreationControlRequestView["surface"]>> = ["code", "cyber"];
@@ -71,19 +72,7 @@ export function RunCreationDialog({ client, open, onClose, initialGoal = "",
       setWorkspaceID(workspaces.data.items[0].id);
     }
   }, [workspaceID, workspaces.data]);
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && !mutation.isPending) {
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [mutation.isPending, onClose, open]);
+  const dialogRef = useModalFocusTrap<HTMLFormElement>(open, onClose, mutation.isPending);
 
   if (!open) {
     return null;
@@ -122,7 +111,7 @@ export function RunCreationDialog({ client, open, onClose, initialGoal = "",
   return (
     <div className="desktop-dialog-backdrop" role="presentation">
       <form aria-labelledby="run-creation-title" aria-modal="true" className="desktop-dialog run-creation-dialog"
-        onSubmit={submit} role="dialog">
+        onSubmit={submit} ref={dialogRef} role="dialog" tabIndex={-1}>
         <header>
           <div>
             <span className="dialog-icon"><Plus aria-hidden="true" size={17} /></span>

--- a/web/src/components/workspace-attachment-dialog.tsx
+++ b/web/src/components/workspace-attachment-dialog.tsx
@@ -1,6 +1,7 @@
 import { FolderOpen, X } from "lucide-react";
 import type { CyberAgentClient } from "../api/client";
 import { WorkspaceExplorer } from "./workspace-explorer";
+import { useModalFocusTrap } from "../hooks/use-modal-focus-trap";
 
 export function WorkspaceAttachmentDialog({ client, open, onClose, runID, workspaceID }: {
   client: CyberAgentClient;
@@ -9,10 +10,12 @@ export function WorkspaceAttachmentDialog({ client, open, onClose, runID, worksp
   runID: string;
   workspaceID: string;
 }) {
+  const dialogRef = useModalFocusTrap<HTMLElement>(open, onClose);
   if (!open) return null;
   return <div className="desktop-dialog-backdrop" role="presentation">
     <section aria-labelledby="workspace-attachment-title" aria-modal="true"
-      className="desktop-dialog workspace-attachment-dialog" role="dialog">
+      className="desktop-dialog workspace-attachment-dialog" ref={dialogRef}
+      role="dialog" tabIndex={-1}>
       <header>
         <div><span className="dialog-icon"><FolderOpen aria-hidden="true" size={17} /></span>
           <div><h2 id="workspace-attachment-title">文件和文件夹</h2>

--- a/web/src/hooks/use-modal-focus-trap.test.tsx
+++ b/web/src/hooks/use-modal-focus-trap.test.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useModalFocusTrap } from "./use-modal-focus-trap";
+
+function Harness({ escapeDisabled = false }: { escapeDisabled?: boolean }) {
+  const [open, setOpen] = useState(false);
+  const dialogRef = useModalFocusTrap<HTMLElement>(open, () => setOpen(false), escapeDisabled);
+  return <>
+    <button onClick={() => setOpen(true)} type="button">Open dialog</button>
+    <a href="#outside">Outside link</a>
+    {open && <section aria-label="Example dialog" aria-modal="true" ref={dialogRef}
+      role="dialog" tabIndex={-1}>
+      <button type="button">First action</button>
+      <button disabled type="button">Disabled action</button>
+      <button type="button">Last action</button>
+    </section>}
+  </>;
+}
+
+describe("useModalFocusTrap", () => {
+  it("keeps tab focus inside the dialog and returns it to the opener", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const opener = screen.getByRole("button", { name: "Open dialog" });
+    await user.click(opener);
+
+    const first = screen.getByRole("button", { name: "First action" });
+    const last = screen.getByRole("button", { name: "Last action" });
+    expect(first).toHaveFocus();
+    await user.tab({ shift: true });
+    expect(last).toHaveFocus();
+    await user.tab();
+    expect(first).toHaveFocus();
+    expect(screen.getByRole("link", { name: "Outside link" })).not.toHaveFocus();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(opener).toHaveFocus();
+  });
+
+  it("keeps a busy dialog open when Escape is disabled", async () => {
+    const user = userEvent.setup();
+    render(<Harness escapeDisabled />);
+    await user.click(screen.getByRole("button", { name: "Open dialog" }));
+    await user.keyboard("{Escape}");
+    expect(screen.getByRole("dialog", { name: "Example dialog" })).toBeInTheDocument();
+  });
+});

--- a/web/src/hooks/use-modal-focus-trap.ts
+++ b/web/src/hooks/use-modal-focus-trap.ts
@@ -1,0 +1,74 @@
+import { useLayoutEffect, useRef, type RefObject } from "react";
+
+const focusableSelector = [
+  "a[href]",
+  "area[href]",
+  "button:not([disabled])",
+  "input:not([disabled]):not([type='hidden'])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[contenteditable='true']",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+function focusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(focusableSelector)).filter((element) =>
+    !element.matches(":disabled") &&
+    !element.closest("[hidden], [inert], [aria-hidden='true']"));
+}
+
+export function useModalFocusTrap<T extends HTMLElement>(open: boolean, onEscape: () => void,
+  escapeDisabled = false, initialFocusRef?: RefObject<HTMLElement | null>) {
+  const dialogRef = useRef<T>(null);
+  const onEscapeRef = useRef(onEscape);
+  const escapeDisabledRef = useRef(escapeDisabled);
+  onEscapeRef.current = onEscape;
+  escapeDisabledRef.current = escapeDisabled;
+
+  useLayoutEffect(() => {
+    if (!open || !dialogRef.current) return;
+    const dialog = dialogRef.current;
+    const previouslyFocused = document.activeElement instanceof HTMLElement
+      ? document.activeElement : null;
+    const candidates = focusableElements(dialog);
+    const preferred = initialFocusRef?.current && dialog.contains(initialFocusRef.current)
+      ? initialFocusRef.current
+      : candidates.find((element) => element.hasAttribute("autofocus")) ?? candidates[0];
+    if (!dialog.contains(document.activeElement)) {
+      (preferred ?? dialog).focus();
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !escapeDisabledRef.current) {
+        event.preventDefault();
+        event.stopPropagation();
+        onEscapeRef.current();
+        return;
+      }
+      if (event.key !== "Tab" || event.altKey || event.ctrlKey || event.metaKey) return;
+      const currentCandidates = focusableElements(dialog);
+      if (currentCandidates.length === 0) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+      const first = currentCandidates[0];
+      const last = currentCandidates.at(-1)!;
+      const active = document.activeElement;
+      if (event.shiftKey && (active === first || !dialog.contains(active))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && (active === last || !dialog.contains(active))) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    dialog.addEventListener("keydown", handleKeyDown);
+    return () => {
+      dialog.removeEventListener("keydown", handleKeyDown);
+      if (previouslyFocused?.isConnected) previouslyFocused.focus();
+    };
+  }, [open]);
+
+  return dialogRef;
+}


### PR DESCRIPTION
## Summary

- add a shared modal focus boundary that moves focus into an opened dialog, cycles Tab/Shift+Tab inside it, handles Escape, and restores focus to the opener
- keep destructive or long-running dialogs open while their operation is pending
- apply the boundary to every existing `aria-modal` surface: command palette, Run creation, model availability, desktop Skill preview, workspace attachments, and Session archive confirmation
- remove duplicate global Escape listeners from the affected dialogs
- add focused hook tests for wraparound, disabled controls, Escape handling, and focus restoration; extend the command-palette regression

## Why

The application declared these surfaces as modal to assistive technology, but keyboard focus could leave the dialog and move through obscured background controls. Closing a dialog also lost the user's location instead of returning focus to the invoking control.

## Validation

- Node.js 24.19.0
- `npm ci` (0 vulnerabilities)
- focused dialog suite: 5 files, 13 tests
- `npm test` (58 files, 220 tests)
- `npm run typecheck`
- `npm run check:api`
- `npm run build`
- `npm audit --audit-level=high` (0 vulnerabilities)
- `git diff --check`

The existing jsdom canvas warnings and Vite large-chunk notice remain informational and unchanged.