### PR TITLE
test: isolate Session composer locale state

### DIFF
--- a/web/src/components/session-composer.test.tsx
+++ b/web/src/components/session-composer.test.tsx
@@ -40,13 +40,13 @@ const cancellationResult: SessionSteeringCancellationView = {
   execution_started: false, model_called: false, tool_called: false, capability_grant: false,
 };
 
-describe("SessionComposer", () => {
-  beforeEach(() => {
-    localStorage.clear();
-    localStorage.setItem("prayu.locale.v1", "en-US");
-    sessionStorage.clear();
-  });
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem("prayu.locale.v1", "en-US");
+  sessionStorage.clear();
+});
 
+describe("SessionComposer", () => {
   it("reuses an in-memory operation key after uncertain failure and clears on success", async () => {
     const submitSessionMessage = vi.fn()
       .mockRejectedValueOnce(new Error("response unavailable"))


### PR DESCRIPTION
## Summary

- move locale and storage reset setup to the file-level test scope
- make `SessionSteeringQueue` tests independent from the earlier `SessionComposer` suite
- preserve the existing storage-persistence assertions

## Why

The queue suite renders through `LocaleProvider` and asserts English labels, but its locale was only initialized by a sibling `describe` block. The full file passed in declaration order while focused queue runs, shuffled execution, or future suite refactors could default to Chinese and fail for reasons unrelated to queue behavior.

## Validation

- Node.js 24.19.0
- `npm ci` (0 vulnerabilities)
- isolated queue suite: 4 passed, 8 skipped
- complete component file: 12/12 passed
- `npm test` (57 files, 218 tests)
- `npm run typecheck`
- `git diff --check`

The existing jsdom canvas warnings remain informational and unchanged.