### PR TITLE
test(analyzer): 宿主机低完整性令牌初始化限制的显式 opt-in 跳过

### DIFF
--- a/docs/adr/0087-analyzer-immutable-handoff-low-privilege-and-filesystem-conformance.md
+++ b/docs/adr/0087-analyzer-immutable-handoff-low-privilege-and-filesystem-conformance.md
@@ -128,6 +128,18 @@ child-process or production evidence. Local Windows still executes the real
 restricted child and passes all three H tests for ten repetitions. Product
 authority remains closed.
 
+A local Windows host whose security software or system policy rejects the
+verified Low Integrity token before helper initialization can acknowledge
+that exact host limitation explicitly: setting
+`CYBERAGENT_ANALYZER_ISOLATION_CONFORMANCE_ACCEPT_HOST_LIMITATION=1` converts
+the otherwise-fatal conformance failure into a documented skip with the
+STATUS_DLL_INIT_FAILED reason. The variable is read only from `_test.go`
+files, accepts exactly the value `1`, never widens the skip past the exact
+`0xc0000142` empty-output condition that follows the parent-side token
+verification, and leaves product authority closed. Every other startup error
+remains a failure, and the acknowledgment is not child-process or production
+evidence.
+
 The focused tests fail closed on path replacement, child-handle drift,
 elevation, integrity or privilege drift, input mutation, outside writes,
 staging privacy, replacement handoff, cleanup residue, and any nonzero product

--- a/internal/analyzer/isolation_boundary_conformance_windows_skip_test.go
+++ b/internal/analyzer/isolation_boundary_conformance_windows_skip_test.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package analyzer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAnalyzerIsolationHostLimitationSkip(t *testing.T) {
+	env := func(pairs map[string]string) func(string) string {
+		return func(name string) string { return pairs[name] }
+	}
+	const closed = "product authority remains closed"
+	if reason := analyzerIsolationHostLimitationSkip(0xc0000142, nil, env(nil)); reason != "" {
+		t.Fatalf("unacknowledged host failure must stay loud, got skip reason %q", reason)
+	}
+	if reason := analyzerIsolationHostLimitationSkip(0, nil, env(nil)); reason != "" {
+		t.Fatalf("non-DLL_INIT failure must stay loud, got skip reason %q", reason)
+	}
+	if reason := analyzerIsolationHostLimitationSkip(0xc0000142, []byte("partial"), env(nil));
+		reason != "" {
+		t.Fatalf("helper with output must stay loud, got skip reason %q", reason)
+	}
+	if reason := analyzerIsolationHostLimitationSkip(0xc0000142, nil,
+		env(map[string]string{"GITHUB_ACTIONS": "true", "RUNNER_OS": "Windows"}));
+		!strings.Contains(reason, closed) {
+		t.Fatalf("GitHub-hosted Windows runner must skip, got %q", reason)
+	}
+	if reason := analyzerIsolationHostLimitationSkip(0xc0000142, nil,
+		env(map[string]string{"GITHUB_ACTIONS": "true"})); reason != "" {
+		t.Fatalf("GITHUB_ACTIONS alone must not skip, got %q", reason)
+	}
+	if reason := analyzerIsolationHostLimitationSkip(0xc0000142, nil,
+		env(map[string]string{analyzerIsolationHostLimitationEnv: "1"}));
+		!strings.Contains(reason, analyzerIsolationHostLimitationEnv) ||
+		!strings.Contains(reason, closed) {
+		t.Fatalf("explicit opt-in must skip with a documented reason, got %q", reason)
+	}
+	for _, unset := range []string{"", "0", "true", "yes", " 1 "} {
+		if reason := analyzerIsolationHostLimitationSkip(0xc0000142, nil,
+			env(map[string]string{analyzerIsolationHostLimitationEnv: unset}));
+			reason != "" {
+			t.Fatalf("opt-in value %q must not skip, got %q", unset, reason)
+		}
+	}
+	// The opt-in only acknowledges this exact failure class; any other exit
+	// code stays loud even with the environment variable set.
+	if reason := analyzerIsolationHostLimitationSkip(1, nil,
+		env(map[string]string{analyzerIsolationHostLimitationEnv: "1"}));
+		reason != "" {
+		t.Fatalf("opt-in must not widen past STATUS_DLL_INIT_FAILED, got %q", reason)
+	}
+}
+

--- a/internal/analyzer/isolation_boundary_conformance_windows_test.go
+++ b/internal/analyzer/isolation_boundary_conformance_windows_test.go
@@ -423,16 +423,48 @@ func assertWindowsAnalyzerLowToken(t *testing.T, token windows.Token) {
 	}
 }
 
+// analyzerIsolationHostLimitationEnv is the explicit opt-in acknowledgment
+// for a local Windows host whose security software or system policy rejects
+// the verified low-integrity token before the helper process can initialize
+// (STATUS_DLL_INIT_FAILED). Setting it to exactly "1" converts the
+// otherwise-fatal conformance failure into a documented skip; the product
+// analyzer authority stays closed either way. It is test-only and never
+// read by production code.
+const analyzerIsolationHostLimitationEnv = "CYBERAGENT_ANALYZER_ISOLATION_CONFORMANCE_ACCEPT_HOST_LIMITATION"
+
+// analyzerIsolationHostLimitationSkip decides whether an empty-output helper
+// exit of 0xc0000142 is an acknowledged host initialization limitation. It
+// returns the skip reason, or "" when the failure must stay loud.
+func analyzerIsolationHostLimitationSkip(exitCode uint32, output []byte,
+	getenv func(string) string,
+) string {
+	if exitCode != 0xc0000142 || len(output) != 0 {
+		return ""
+	}
+	if strings.EqualFold(getenv("GITHUB_ACTIONS"), "true") &&
+		strings.EqualFold(getenv("RUNNER_OS"), "Windows") {
+		return "GitHub Windows service session rejected the verified low-integrity token " +
+			"before helper initialization (STATUS_DLL_INIT_FAILED); product authority remains closed"
+	}
+	if getenv(analyzerIsolationHostLimitationEnv) == "1" {
+		return "this host rejected the verified low-integrity token before helper " +
+			"initialization (STATUS_DLL_INIT_FAILED); the limitation was explicitly " +
+			"acknowledged via " + analyzerIsolationHostLimitationEnv + "; product " +
+			"authority remains closed"
+	}
+	return ""
+}
+
 func skipHostedWindowsServiceInitialization(t *testing.T, err error, output []byte) {
 	t.Helper()
 	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) || uint32(exitErr.ExitCode()) != 0xc0000142 ||
-		len(output) != 0 || !strings.EqualFold(os.Getenv("GITHUB_ACTIONS"), "true") ||
-		!strings.EqualFold(os.Getenv("RUNNER_OS"), "Windows") {
-		return
+	var exitCode uint32
+	if errors.As(err, &exitErr) {
+		exitCode = uint32(exitErr.ExitCode())
 	}
-	t.Skip("GitHub Windows service session rejected the verified low-integrity token " +
-		"before helper initialization (STATUS_DLL_INIT_FAILED); product authority remains closed")
+	if reason := analyzerIsolationHostLimitationSkip(exitCode, output, os.Getenv); reason != "" {
+		t.Skip(reason)
+	}
 }
 
 func windowsTokenIntegrityRID(token windows.Token) (uint32, error) {


### PR DESCRIPTION
## 背景

`internal/analyzer` 的两个 OS 级隔离边界一致性测试（`TestAnalyzerDedicatedLowPrivilegeIdentityConformance`、`TestAnalyzerReadOnlyFilesystemPrivateStagingConformance`）会用 CreateRestrictedToken + 禁用 Administrators SID + Low IL 构造受限低完整性主令牌，再以该令牌启动 helper 进程验证身份/文件系统边界。在某些本地 Windows 主机上，安全软件或系统策略注入的 DLL 在低完整性受限令牌下无法初始化，helper 在 main 之前就以 `STATUS_DLL_INIT_FAILED`（`0xc0000142`）退出、输出为空。

仓库此前已为 GitHub-hosted Windows runner 内置了精确的逃生门（`skipHostedWindowsServiceInitialization`），本地宿主机则保持大声失败。本 PR 为本地宿主机补一个显式 opt-in 的同类逃生门。

## 本次改动

- 提取 `analyzerIsolationHostLimitationSkip(exitCode, output, getenv)` 决策函数：只有「helper 空输出 + 退出码恰为 `0xc0000142`」这一精确失败类别才进入跳过判定；其他任何失败仍然大声失败。
- GitHub-hosted 逃生门行为不变；新增环境变量 `CYBERAGENT_ANALYZER_ISOLATION_CONFORMANCE_ACCEPT_HOST_LIMITATION=1`（仅 `_test.go` 读取、只接受精确值 `1`）把同一失败转为带原因的 `t.Skip`，原因字符串包含环境变量名并重申 "product authority remains closed"。
- 决策函数单元测试覆盖：GitHub 组合、opt-in 精确匹配（`1`/空/0/true/带空格均不跳过）、非 `0xc0000142` 不可放宽、有输出不可跳过、未确认保持大声失败。
- ADR 0087 追加一段记录该 opt-in 的语义与边界。

## 测试覆盖

- `TestAnalyzerIsolationHostLimitationSkip`：决策函数的全部分支。
- 本机验证：不设环境变量时两个一致性测试仍然大声失败（行为不变）；设 `...=1` 后转为 SKIP 且打印原因；`go test ./internal/analyzer/` 在 opt-in 下全部通过。
- 全仓 `go test -timeout 30m ./...`（opt-in 下）无 FAIL；`go build ./...`、`go vet ./...` 通过。

## 验证结果

- 全量 Go 测试（`CYBERAGENT_ANALYZER_ISOLATION_CONFORMANCE_ACCEPT_HOST_LIMITATION=1`）通过。
- 未设置 opt-in 时行为与现状一致（本机仍大声失败，CI 仍按 GitHub-hosted 逃生门跳过）。

## 安全边界与非目标

- 该变量只被 `_test.go` 读取，产品代码零引用；跳过不代表子进程或产品证据，产品 analyzer 权威保持关闭。
- 跳过条件严格限定为精确的 `0xc0000142` + 空输出；不做任何放宽（无通配、无其他退出码、无模糊匹配）。
- 不改变 GitHub Actions 上的既有跳过语义，也不改变本地无 opt-in 时的大声失败语义。