### PR TITLE
fix(browser): 授予启动令牌完整权限以通过 WFP 生产验收

### DIFF
--- a/docs/adr/0103-full-access-launch-token-for-browser-de-elevation.md
+++ b/docs/adr/0103-full-access-launch-token-for-browser-de-elevation.md
@@ -1,0 +1,36 @@
+# ADR 0103: Full-Access Launch Token For Browser De-Elevation
+
+Status: accepted
+
+Date: 2026-08-16
+
+## Context
+
+The Windows production probe runs elevated so it can install WFP filters, then
+must launch the browser as the same user's non-elevated, medium-integrity
+primary token. On Microsoft-account (MSA) administrator tokens the elevated
+token lacks `SeAssignPrimaryTokenPrivilege`, so `CreateProcessAsUser` can never
+de-elevate. The `CreateProcessWithTokenW` fallback — which requires only
+`SeImpersonatePrivilege` — is therefore the sole route, but it was rejecting
+the launch token with `ERROR_ACCESS_DENIED` at the `process_create_with_token`
+stage.
+
+## Decision
+
+Duplicate the trusted interactive-shell (`explorer.exe`) token with
+`TOKEN_ALL_ACCESS` instead of the documented minimum
+`TOKEN_QUERY|TOKEN_DUPLICATE|TOKEN_ASSIGN_PRIMARY`. `CreateProcessWithTokenW`
+needs more than that minimum on a restricted-access duplicate and otherwise
+fails closed with `access_denied`. The token is still validated before any use:
+same user, same session, non-elevated, medium integrity, primary type, and a
+trusted `explorer.exe` system path.
+
+## Consequences
+
+An administrator production probe now passes on an MSA machine (verified
+against an accepted Chrome install): all eleven acceptance flags are true, the
+child is a same-user / same-session / non-elevated / medium-integrity primary
+token bound to the restricted Job before resume, and no WFP rules, browser
+processes, or temporary Profile remain. The token is duplicated from a
+rigorously validated source and used only to launch the browser, so full access
+does not widen any product authority. Issue #1 is unblocked.

--- a/internal/browserruntime/browser_process_windows.go
+++ b/internal/browserruntime/browser_process_windows.go
@@ -344,8 +344,13 @@ func acquireWindowsInteractiveShellPrimaryToken(parent windows.Token) (windows.T
 		return 0, err
 	}
 	var primary windows.Token
-	desiredAccess := uint32(windows.TOKEN_QUERY | windows.TOKEN_DUPLICATE |
-		windows.TOKEN_ASSIGN_PRIMARY)
+	// The duplicated primary token needs full access, not just the documented
+	// TOKEN_QUERY|TOKEN_DUPLICATE|TOKEN_ASSIGN_PRIMARY minimum: CreateProcessWithTokenW
+	// (the SeAssignPrimaryToken-free fallback used to de-elevate the browser)
+	// rejects a restricted-access token with ERROR_ACCESS_DENIED. The token is
+	// still validated to be the trusted interactive shell's same-user, same-session,
+	// non-elevated, medium-integrity primary token before it is used anywhere.
+	desiredAccess := uint32(windows.TOKEN_ALL_ACCESS)
 	if err := windows.DuplicateTokenEx(shellToken, desiredAccess, nil,
 		windows.SecurityImpersonation, windows.TokenPrimary, &primary); err != nil {
 		return 0, err


### PR DESCRIPTION
## 背景

issue #1：Windows WFP 受限浏览器生产探针长期停留在管理员验收，最后一次记录证据是 `baseline_process_create_with_token_invalid_parameter`，且注明 `20865b5` 之后未再验收。本机（Microsoft 账户管理员）实测当前失败码已不是 `invalid_parameter`，而是 `baseline_process_create_with_token_access_denied`：提权 token 缺少 `SeAssignPrimaryTokenPrivilege`，`CreateProcessAsUser` 永远走不通；而仅需 `SeImpersonatePrivilege` 的兜底 `CreateProcessWithTokenW` 又拿不到一个受限权限的令牌，直接 `ERROR_ACCESS_DENIED`。

## 本次改动

- `acquireWindowsInteractiveShellPrimaryToken` 复制可信 `explorer.exe` 令牌时，把 `desiredAccess` 从文档最小集 `TOKEN_QUERY|TOKEN_DUPLICATE|TOKEN_ASSIGN_PRIMARY` 改为 `TOKEN_ALL_ACCESS`：`CreateProcessWithTokenW` 在受限权限副本上需要更多权限，否则在 `process_create_with_token` 阶段 fail closed 为 `access_denied`。
- 令牌仍在使用前被严格校验：同用户、同会话、非提权、中完整性、Primary 类型、可信 `explorer.exe` 系统路径。
- 新增 ADR 0103，记录 MSA 管理员令牌缺权与本次访问权限放宽的决策。

## 测试覆盖

- `internal/browserruntime` 全量 `go test -count=1` 通过。
- `internal/app`（含 doctor 命令路径）全量通过。
- `browserNetworkProbeRunFailureCode` 的既有失败码分类用例不受影响。

## 验证结果

- `go build ./...`、`go vet ./...` 通过。
- 管理员生产探针（`doctor browser-network-probe --product chrome --confirm RUN-LOCAL-WFP-BROWSER-PROBE`，UAC 提权）实测通过：11 项验收全绿（`dynamic_session_observed` / `atomic_install_observed` / `exact_target_observed` / `wrong_port_denied` / `wrong_loopback_address_denied` / `non_loopback_address_denied` / `ipv6_denied` / `rule_cleanup_observed` 均为 true，`synthetic=false`、`production=true`、`passed=true`），退出码 0；探针结束后无残留 WFP 规则、浏览器进程或临时 Profile，子进程为同用户/同会话/非提权/中完整性 Primary Token 并在恢复前绑定到受限 Job。

## 安全边界与非目标

- 令牌来源不变（可信 `explorer.exe`），使用前仍做同用户/同会话/非提权/中完整性/系统路径严格校验；`TOKEN_ALL_ACCESS` 只作用于这一枚被复制、被校验、且仅用于启动浏览器的令牌，不扩展任何产品授权面。
- 不改变 WFP 规则、浏览器启动参数、Profile 生命周期或任何网络/启动授权语义；非管理员路径行为不变。
- 探针仍需显式 `--confirm RUN-LOCAL-WFP-BROWSER-PROBE` 且必须管理员运行；受限浏览器产品入口（C8C）仍保持关闭，本 PR 只补齐其生产证据。

Closes #1
