### PR TITLE
feat(ui): 价格快照、Docker 沙箱、Skill 安装与字段级投影补齐

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2,6 +2,15 @@ import { consumeSSE } from "./sse";
 import type {
   ApprovalDecisionControlRequestView,
   ChildTaskAdmitRequestView,
+  DockerSandboxAdmissionRequestView,
+  DockerSandboxAdmissionView,
+  DockerSandboxCancelRequestView,
+  DockerSandboxCancellationView,
+  DockerSandboxStartRequestView,
+  DockerSandboxStatusView,
+  PriceSnapshotImportRequestView,
+  PriceSnapshotImportView,
+  PriceSnapshotListView,
   ChildTaskProposalsListView,
   ChildTaskProposalView,
   ChildTaskReviewRequestView,
@@ -4242,6 +4251,72 @@ export class CyberAgentClient {
     );
     return parseChildTaskProposal(result, runID);
   }
+  async listPriceSnapshots(signal?: AbortSignal): Promise<PriceSnapshotListView> {
+    const result = await this.get<unknown>("/models/prices", {}, signal);
+    return parsePriceSnapshots(result);
+  }
+
+  async importPriceSnapshot(body: PriceSnapshotImportRequestView, idempotencyKey: string,
+    signal?: AbortSignal): Promise<PriceSnapshotImportView> {
+    if (!this.hasControl) {
+      throw new Error("A control bearer token is required for this operation");
+    }
+    if (body.version !== "price_snapshot.v1" || !body.document ||
+      body.document.length > 64 * 1024) {
+      throw new Error("A bounded price_snapshot.v1 document is required");
+    }
+    const result = await this.sendControl<unknown>("/models/prices", body, idempotencyKey, signal);
+    return parsePriceSnapshotImport(result);
+  }
+
+  async getDockerSandboxStatus(admissionID: string,
+    signal?: AbortSignal): Promise<DockerSandboxStatusView> {
+    const result = await this.get<unknown>("/sandbox/docker/status", { admission_id: admissionID }, signal);
+    if (!isRecord(result) || !boundedIdentity(String(result.admission_id))) {
+      throw new APIRequestError("Docker sandbox status is invalid", "INVALID_RESPONSE", 502);
+    }
+    return result as unknown as DockerSandboxStatusView;
+  }
+
+  async admitDockerSandbox(body: DockerSandboxAdmissionRequestView, idempotencyKey: string,
+    signal?: AbortSignal): Promise<DockerSandboxAdmissionView> {
+    if (!this.hasControl) {
+      throw new Error("A control bearer token is required for this operation");
+    }
+    if (!boundedIdentity(body.plan_id) || !boundedIdentity(body.requested_by) ||
+      !isRecord(body.manifest)) {
+      throw new Error("A plan identity, requester, and manifest object are required");
+    }
+    const result = await this.sendControl<unknown>("/sandbox/docker/admissions", body, idempotencyKey, signal);
+    if (!isRecord(result) || typeof result.allowed !== "boolean") {
+      throw new APIRequestError("Docker sandbox admission is invalid", "INVALID_RESPONSE", 502);
+    }
+    return result as unknown as DockerSandboxAdmissionView;
+  }
+
+  async startDockerSandbox(body: DockerSandboxStartRequestView, idempotencyKey: string,
+    signal?: AbortSignal): Promise<DockerSandboxStatusView> {
+    if (!this.hasControl) {
+      throw new Error("A control bearer token is required for this operation");
+    }
+    if (!boundedIdentity(body.admission_id) || !boundedIdentity(body.requested_by)) {
+      throw new Error("An admission identity and requester are required");
+    }
+    const result = await this.sendControl<unknown>("/sandbox/docker/starts", body, idempotencyKey, signal);
+    return result as unknown as DockerSandboxStatusView;
+  }
+
+  async cancelDockerSandbox(body: DockerSandboxCancelRequestView, idempotencyKey: string,
+    signal?: AbortSignal): Promise<DockerSandboxCancellationView> {
+    if (!this.hasControl) {
+      throw new Error("A control bearer token is required for this operation");
+    }
+    if (!boundedIdentity(body.admission_id) || !boundedIdentity(body.requested_by)) {
+      throw new Error("An admission identity and requester are required");
+    }
+    const result = await this.sendControl<unknown>("/sandbox/docker/cancellations", body, idempotencyKey, signal);
+    return result as unknown as DockerSandboxCancellationView;
+  }
   async selectPlanDirection(runID: string, body: PlanDirectionControlRequestView,
     idempotencyKey: string, signal?: AbortSignal): Promise<PlanDirectionControlView> {
     if (!this.hasPlanDelivery) {
@@ -4638,4 +4713,26 @@ function parseChildTaskProposal(value: unknown, runID: string): ChildTaskProposa
     }
   }
   return value as unknown as ChildTaskProposalView;
+}
+function parsePriceSnapshots(value: unknown): PriceSnapshotListView {
+  if (!isRecord(value) || value.protocol_version !== "price_snapshot_list.v1" ||
+    !Array.isArray(value.items) || value.items.length > 32) {
+    throw new APIRequestError("Price snapshot list is invalid", "INVALID_RESPONSE", 502);
+  }
+  for (const item of value.items) {
+    if (!isRecord(item) || !boundedIdentity(String(item.id)) || !validDate(item.imported_at) ||
+      !Array.isArray(item.entries) || item.entries.length > 512) {
+      throw new APIRequestError("Price snapshot item is invalid", "INVALID_RESPONSE", 502);
+    }
+  }
+  return value as unknown as PriceSnapshotListView;
+}
+
+function parsePriceSnapshotImport(value: unknown): PriceSnapshotImportView {
+  if (!isRecord(value) || value.protocol_version !== "price_snapshot.v1" ||
+    !boundedIdentity(String(value.id)) || !boundedIdentity(String(value.fingerprint)) ||
+    !safeBoundedCount(value.entry_count, 512) || typeof value.replayed !== "boolean") {
+    throw new APIRequestError("Price snapshot import is invalid", "INVALID_RESPONSE", 502);
+  }
+  return value as unknown as PriceSnapshotImportView;
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -26,6 +26,15 @@ export type ChildTaskProposalsListView = components["schemas"]["ChildTaskProposa
 export type ChildTaskProposalView = components["schemas"]["ChildTaskProposalView"];
 export type ChildTaskReviewRequestView = components["schemas"]["ChildTaskReviewRequestView"];
 export type ChildTaskAdmitRequestView = components["schemas"]["ChildTaskAdmitRequestView"];
+export type PriceSnapshotListView = components["schemas"]["PriceSnapshotListView"];
+export type PriceSnapshotImportRequestView = components["schemas"]["PriceSnapshotImportRequestView"];
+export type PriceSnapshotImportView = components["schemas"]["PriceSnapshotImportView"];
+export type DockerSandboxStatusView = components["schemas"]["DockerSandboxStatusView"];
+export type DockerSandboxAdmissionRequestView = components["schemas"]["DockerSandboxAdmissionRequestView"];
+export type DockerSandboxAdmissionView = components["schemas"]["DockerSandboxAdmissionView"];
+export type DockerSandboxStartRequestView = components["schemas"]["DockerSandboxStartRequestView"];
+export type DockerSandboxCancelRequestView = components["schemas"]["DockerSandboxCancelRequestView"];
+export type DockerSandboxCancellationView = components["schemas"]["DockerSandboxCancellationView"];
 export type FanoutExecutionView = components["schemas"]["FanoutExecutionView"];
 export type FanoutExecutionCancelRequestView =
   components["schemas"]["FanoutExecutionCancelRequestView"];

--- a/web/src/components/docker-sandbox-panel.tsx
+++ b/web/src/components/docker-sandbox-panel.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Box, LoaderCircle, Server } from "lucide-react";
+import type { CyberAgentClient } from "../api/client";
+import { ErrorState, LoadingState, StatusBadge } from "./common";
+import { useLocale } from "../lib/locale";
+
+export function DockerSandboxPanel({ client }: { client: CyberAgentClient }) {
+  const { t } = useLocale();
+  const [planID, setPlanID] = useState("");
+  const [manifest, setManifest] = useState("");
+  const [admissionID, setAdmissionID] = useState("");
+  const [lastAdmission, setLastAdmission] = useState("");
+  const [message, setMessage] = useState("");
+  const statusQuery = useQuery({
+    queryKey: ["sandbox", "docker", "status", admissionID],
+    queryFn: ({ signal }) => client.getDockerSandboxStatus(admissionID, signal),
+    enabled: Boolean(admissionID),
+  });
+  const admit = useMutation({
+    mutationFn: () => {
+      let parsed: unknown;
+      try { parsed = JSON.parse(manifest); } catch { throw new Error("manifest must be valid JSON"); }
+      return client.admitDockerSandbox({ plan_id: planID, requested_by: "web_operator", manifest: parsed as never },
+        `web-docker-admit-${globalThis.crypto.randomUUID()}`);
+    },
+    onSuccess: (result) => {
+      setLastAdmission(result.admission_id ?? "");
+      setAdmissionID(result.admission_id ?? "");
+      setMessage(result.allowed ? "admission authorized" : "admission denied");
+    },
+  });
+  const start = useMutation({
+    mutationFn: () => client.startDockerSandbox({ admission_id: admissionID, requested_by: "web_operator" },
+      `web-docker-start-${globalThis.crypto.randomUUID()}`),
+    onSuccess: () => setMessage("start request accepted"),
+  });
+  const cancel = useMutation({
+    mutationFn: () => client.cancelDockerSandbox({ admission_id: admissionID, requested_by: "web_operator" },
+      `web-docker-cancel-${globalThis.crypto.randomUUID()}`),
+    onSuccess: () => setMessage("cancellation accepted"),
+  });
+  return (
+    <section className="detail-section docker-sandbox-section" aria-label={t("Docker 沙箱", "Docker sandbox")}>
+      <div className="section-heading"><h2><Server aria-hidden="true" size={15} />{t("Docker 沙箱", "Docker sandbox")}</h2><span>{t("network-none 精确准入", "network-none exact admission")}</span></div>
+      <div className="run-execution-control">
+        <label htmlFor="docker-plan-id">{t("计划 ID", "Plan ID")}</label>
+        <input id="docker-plan-id" maxLength={256} onChange={(event) => setPlanID(event.target.value)} value={planID} />
+      </div>
+      <div className="run-execution-control">
+        <label htmlFor="docker-manifest">{t("Manifest JSON", "Manifest JSON")}</label>
+        <textarea id="docker-manifest" onChange={(event) => setManifest(event.target.value)} rows={8} value={manifest} />
+      </div>
+      {client.hasControl && (
+        <button className="command-button" disabled={admit.isPending || !planID || !manifest}
+          onClick={() => admit.mutate()} type="button">
+          {admit.isPending ? <LoaderCircle aria-hidden="true" className="spin" size={15} /> : <Box aria-hidden="true" size={15} />}
+          {t("评估并准入", "Evaluate and admit")}
+        </button>
+      )}
+      <div className="run-execution-control">
+        <label htmlFor="docker-admission-id">{t("准入 ID", "Admission ID")}</label>
+        <input id="docker-admission-id" maxLength={256} onChange={(event) => setAdmissionID(event.target.value)} value={admissionID} />
+      </div>
+      {statusQuery.data && (
+        <dl className="detail-grid compact">
+          <div><dt>{t("状态", "Status")}</dt><dd><StatusBadge status={String(statusQuery.data.state)} /></dd></div>
+          <div><dt>{t("决策", "Decision")}</dt><dd>{String(statusQuery.data.decision)}</dd></div>
+        </dl>
+      )}
+      {client.hasControl && admissionID && (
+        <div className="run-execution-control">
+          <button className="command-button" disabled={start.isPending} onClick={() => start.mutate()} type="button">{t("启动", "Start")}</button>
+          <button className="command-button danger" disabled={cancel.isPending} onClick={() => cancel.mutate()} type="button">{t("取消", "Cancel")}</button>
+        </div>
+      )}
+      {message && <div className="projection-placeholder" role="status">{message}</div>}
+      {lastAdmission && !admissionID && <div className="projection-placeholder">{t("最近准入", "Latest admission")}: {lastAdmission}</div>}
+      {(admit.isError || start.isError || cancel.isError) && <div className="inline-warning" role="alert">
+        {String((admit.isError ? admit.error : start.isError ? start.error : cancel.error) ?? t("Docker 沙箱操作失败", "Docker sandbox operation failed"))}
+      </div>}
+    </section>
+  );
+}
+

--- a/web/src/components/evidence-inventory.tsx
+++ b/web/src/components/evidence-inventory.tsx
@@ -35,7 +35,7 @@ export function EvidenceInventory({ client, runID, onOpenSource }: {
     {query.data && query.data.items.length > 0 && <div className="evidence-inventory-list">
       {query.data.items.map((item) => <div key={item.attachment_id}>
         <ShieldCheck aria-hidden="true" size={16} />
-        <span><strong>{item.source_ref}</strong><code>{item.content_sha256}</code></span>
+        <span><strong>{item.source_ref}</strong><code>{item.content_sha256}</code>{item.instruction_authorized && <small>{t("含授权指令", "instruction authorized")}</small>}</span>
         <time dateTime={item.attached_at}>{formatDate(item.attached_at)}</time>
         <button aria-label={t(`打开 ${item.source_ref}`, `Open ${item.source_ref}`)} className="icon-button"
           onClick={() => onOpenSource(item.source_ref)} title={t("打开来源", "Open source")} type="button">

--- a/web/src/components/model-availability-dialog.tsx
+++ b/web/src/components/model-availability-dialog.tsx
@@ -6,6 +6,7 @@ import type { ModelHarnessQualificationView, ProviderDiagnosticView } from "../a
 import { ErrorState, LoadingState, StatusBadge } from "./common";
 import { useLocale } from "../lib/locale";
 import { useModalFocusTrap } from "../hooks/use-modal-focus-trap";
+import { PriceSnapshotsSection } from "./price-snapshots-panel";
 
 export function ModelAvailabilityDialog({ client, open, onClose }: {
   client: CyberAgentClient;
@@ -291,6 +292,7 @@ function ModelAvailabilitySurface({ client, open, onClose, presentation }: {
                   {credentialError}
                 </div>}
               </section>}
+              <PriceSnapshotsSection client={client} />
               <section className="model-availability-section">
                 <h3><Route aria-hidden="true" size={14} />{t("模型路由", "Routes")}</h3>
                 <div className="model-route-list">

--- a/web/src/components/operation-receipt.tsx
+++ b/web/src/components/operation-receipt.tsx
@@ -14,6 +14,7 @@ export function OperationReceipt({ receipt }: { receipt: OperationReceiptView })
     <div>
       <strong>{receipt.outcome}</strong>
       <span>{receipt.kind.replaceAll("_", " ")} / {t("持久化", "durable")}{receipt.replayed ? t(" / 已重放", " / replayed") : ""}</span>
+      {(receipt.retry_strategy || receipt.recovery_action) && <small>{t("重试", "Retry")}: {receipt.retry_strategy || "-"} · {t("恢复", "Recovery")}: {receipt.recovery_action || "-"}</small>}
       {failed && <small>{t("相同操作键会重放这份持久化失败结果。", "The durable failed result will replay for the same operation key.")}</small>}
       {pending && <small>{t("暂存区等待清理；请在清理宽限期后使用相同操作键重试。", "Staging cleanup is pending. Retry the same operation after the cleanup grace period.")}</small>}
     </div>

--- a/web/src/components/price-snapshots-panel.tsx
+++ b/web/src/components/price-snapshots-panel.tsx
@@ -1,0 +1,58 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { LoaderCircle, Tag } from "lucide-react";
+import type { CyberAgentClient } from "../api/client";
+import { ErrorState, LoadingState } from "./common";
+import { useLocale } from "../lib/locale";
+
+export function PriceSnapshotsSection({ client }: { client: CyberAgentClient }) {
+  const { t } = useLocale();
+  const queryClient = useQueryClient();
+  const [document, setDocument] = useState("");
+  const query = useQuery({
+    queryKey: ["models", "prices"],
+    queryFn: ({ signal }) => client.listPriceSnapshots(signal),
+  });
+  const importMutation = useMutation({
+    mutationFn: () => client.importPriceSnapshot({ version: "price_snapshot.v1", document },
+      `web-price-import-${globalThis.crypto.randomUUID()}`),
+    onSuccess: () => {
+      setDocument("");
+      void queryClient.invalidateQueries({ queryKey: ["models", "prices"] });
+    },
+  });
+  return (
+    <section className="model-availability-section">
+      <h3><Tag aria-hidden="true" size={14} />{t("价格快照", "Price snapshots")}</h3>
+      {query.isLoading && <LoadingState label={t("加载价格快照", "Loading price snapshots")} />}
+      {query.isError && <ErrorState error={query.error} />}
+      {query.data && (
+        <div className="provider-credential-list">
+          {query.data.items.length === 0 && <div className="projection-placeholder">{t("尚无导入", "none imported")}</div>}
+          {query.data.items.map((item) => (
+            <div className="provider-credential-row" key={item.id}>
+              <div><strong>{item.id}</strong><small>{item.source} · {item.currency} · {item.entry_count} {t("条", "entries")}</small></div>
+              <code>{item.fingerprint.slice(0, 16)}</code>
+            </div>
+          ))}
+        </div>
+      )}
+      {client.hasControl && (
+        <div className="run-execution-control">
+          <textarea aria-label={t("价格文档", "price_snapshot.v1 document")} onChange={(event) => setDocument(event.target.value)}
+            placeholder='{"protocol_version":"price_snapshot.v1","id":"...","source":"operator_import","currency":"USD","imported_by":"operator","valid_from":"...","valid_until":"...","entries":[...]}'
+            rows={6} value={document} />
+          <button className="command-button" disabled={importMutation.isPending || !document}
+            onClick={() => importMutation.mutate()} type="button">
+            {importMutation.isPending ? <LoaderCircle aria-hidden="true" className="spin" size={15} /> : <Tag aria-hidden="true" size={15} />}
+            {t("导入", "Import")}
+          </button>
+          {importMutation.error && <div className="inline-warning" role="alert">
+            {importMutation.error instanceof Error ? importMutation.error.message : t("价格导入失败", "Price import failed")}
+          </div>}
+        </div>
+      )}
+    </section>
+  );
+}
+

--- a/web/src/components/run-projections.tsx
+++ b/web/src/components/run-projections.tsx
@@ -215,6 +215,8 @@ export function DelegationsPanel({ client, runID }: ProjectionProps) {
           <dl className="projection-metrics">
             <Metric label={t("审阅", "Review")} value={item.review ? `${item.review.decision} · ${item.review.reviewed_by}` : t("待处理", "pending")} />
             <Metric label={t("应用", "Application")} value={item.application?.status ?? "-"} />
+            {item.application && <Metric label={t("准入上限", "Admission caps")} value={`${item.application.max_children} child · ${formatNumber(item.application.max_turns_per_child)} 回合 · ${formatNumber(item.application.max_tokens_per_child)} Tokens`} />}
+            {item.application?.stop_code && <Metric label={t("停止原因", "Stop code")} value={item.application.stop_code} />}
             <Metric label={t("调度", "Schedule")} value={item.latest_schedule?.status ?? (item.latest_schedule ? t("已请求", "requested") : "-")} />
             <Metric label={t("创建时间", "Created")} value={formatDate(item.created_at)} />
           </dl>
@@ -243,6 +245,10 @@ export function FanoutPanel({ client, runID }: ProjectionProps) {
           </header>
           <dl className="projection-metrics">
             <Metric label={t("档位", "Tier")} value={`${plan.requested_tier} → ${plan.effective_parallelism}`} />
+            <Metric label={t("范围", "Scope")} value={plan.scope_path} />
+            <Metric label={t("分片数", "Shards")} value={formatNumber(plan.shard_count)} />
+            {plan.latest_execution && <Metric label={t("单分片输出上限", "Max output/shard")} value={formatNumber(plan.latest_execution.max_output_tokens_per_shard)} />}
+            {plan.latest_execution?.stop_code && <Metric label={t("停止原因", "Stop code")} value={plan.latest_execution.stop_code} />}
             <Metric label={t("文件", "Files")} value={formatNumber(plan.file_count)} />
             <Metric label={t("输入", "Input")} value={formatBytes(plan.total_bytes)} />
             <Metric label={t("已排除", "Excluded")} value={formatNumber(plan.excluded_count)} />
@@ -401,8 +407,8 @@ export function ChildTasksPanel({ client, runID }: ProjectionProps) {
 function ShardTable({ execution }: { execution: NonNullable<FanoutPlanView["latest_execution"]> }) {
   const { t } = useLocale();
   return (
-    <div className="table-scroll shard-table"><table><thead><tr><th>{t("分片", "Shard")}</th><th>{t("状态", "Status")}</th><th>{t("模型", "Model")}</th><th>{t("令牌", "Tokens")}</th><th>{t("发现", "Findings")}</th><th>{t("耗时", "Duration")}</th></tr></thead><tbody>
-      {execution.shards.map((shard) => <tr key={shard.ordinal}><td>#{shard.ordinal}</td><td><StatusBadge status={shard.status} /></td><td>{shard.provider && shard.model ? `${shard.provider}/${shard.model}` : "-"}</td><td>{formatNumber(shard.total_tokens)}</td><td>{formatNumber(shard.finding_count)}</td><td>{formatNumber(shard.elapsed_millis)} ms</td></tr>)}
+    <div className="table-scroll shard-table"><table><thead><tr><th>{t("分片", "Shard")}</th><th>{t("状态", "Status")}</th><th>{t("模型", "Model")}</th><th>{t("尝试", "Attempt")}</th><th>{t("输入", "In")}</th><th>{t("输出", "Out")}</th><th>{t("发现", "Findings")}</th><th>{t("耗时", "Duration")}</th><th>{t("错误", "Error")}</th></tr></thead><tbody>
+      {execution.shards.map((shard) => <tr key={shard.ordinal}><td>#{shard.ordinal}</td><td><StatusBadge status={shard.status} /></td><td>{shard.provider && shard.model ? `${shard.provider}/${shard.model}` : "-"}</td><td>{formatNumber(shard.current_attempt)}/{formatNumber(shard.attempt_count)}</td><td>{formatNumber(shard.input_tokens)}</td><td>{formatNumber(shard.output_tokens)}</td><td>{formatNumber(shard.finding_count)}</td><td>{formatNumber(shard.elapsed_millis)} ms</td><td>{shard.error_code || "-"}</td></tr>)}
     </tbody></table></div>
   );
 }

--- a/web/src/components/run-workspace.tsx
+++ b/web/src/components/run-workspace.tsx
@@ -26,6 +26,7 @@ import {
   Play,
   Radio,
   ScanSearch,
+  Server,
   ShieldAlert,
   ShieldCheck,
   ShieldOff,
@@ -87,10 +88,11 @@ import { SessionComposer } from "./session-composer";
 import { AgentGraphPanel, ChildTasksPanel, DelegationsPanel, ExternalSkillsSection, FanoutPanel, FindingsPanel } from "./run-projections";
 import { RunActivityTimeline } from "./run-activity-timeline";
 import { EmbeddedAnalyzerPanel } from "./embedded-analyzer-panel";
+import { DockerSandboxPanel } from "./docker-sandbox-panel";
 
 export type RunTab = "activity" | "overview" | "journey" | "actions" | "approvals" | "diffs" | "repository" | "files" | "evidence" | "verify" | "handoff" |
   "receipts" | "agents" | "delegations" | "fanout" | "findings" | "events" | "work" |
-  "notes" | "artifacts" | "tools" | "analyzer" | "child-tasks";
+  "notes" | "artifacts" | "tools" | "analyzer" | "child-tasks" | "sandbox";
 
 const tabs: Array<{ id: RunTab; label: [string, string]; icon: typeof Activity }> = [
   { id: "activity", label: ["活动", "Activity"], icon: MessageSquareText },
@@ -116,6 +118,7 @@ const tabs: Array<{ id: RunTab; label: [string, string]; icon: typeof Activity }
   { id: "artifacts", label: ["产物", "Artifacts"], icon: FileArchive },
   { id: "tools", label: ["工具", "Tools"], icon: Wrench },
   { id: "analyzer", label: ["分析器", "Analyzer"], icon: Bug },
+  { id: "sandbox", label: ["沙箱", "Sandbox"], icon: Server },
 ];
 
 const compactTabs = new Set<RunTab>(["activity", "approvals", "diffs", "repository", "files"]);
@@ -382,6 +385,7 @@ export function RunWorkspace({ client, runID, onOpenPlugins }: {
         {tab === "delegations" && <DelegationsPanel client={client} runID={runID} />}
         {tab === "fanout" && <FanoutPanel client={client} runID={runID} />}
         {tab === "child-tasks" && <ChildTasksPanel client={client} runID={runID} />}
+        {tab === "sandbox" && <DockerSandboxPanel client={client} />}
         {tab === "findings" && <FindingsPanel client={client} runID={runID} />}
         {tab === "events" && (
           <CollectionState query={eventsQuery} empty="暂无事件">

--- a/web/src/components/settings-view.tsx
+++ b/web/src/components/settings-view.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import { useMutation } from "@tanstack/react-query";
 import {
   ArrowLeft,
   CircleUserRound,
   Cpu,
   Info,
+  LoaderCircle,
   Keyboard,
   Languages,
   Layers3,
@@ -65,6 +67,42 @@ function readSettingsSidebarWidth(): number {
   } catch {
     return defaultSidebarWidth;
   }
+}
+
+function WebSkillInstall({ client }: { client: CyberAgentClient }) {
+  const { t } = useLocale();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [message, setMessage] = useState("");
+  const install = useMutation({
+    mutationFn: (file: File) => file.arrayBuffer().then((buffer) => {
+      let binary = "";
+      const bytes = new Uint8Array(buffer);
+      const chunk = 0x8000;
+      for (let i = 0; i < bytes.length; i += chunk) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+      }
+      return client.installSkillPackage({
+        version: "skill_package_installation.v1", archive_base64: btoa(binary),
+        surface: "code", confirm_untrusted: true,
+      }, `web-skill-install-${globalThis.crypto.randomUUID()}`);
+    }),
+    onSuccess: () => setMessage(t("Skill 包已安装", "Skill package installed")),
+  });
+  return <div className="settings-web-skill">
+    <input accept="application/zip" hidden ref={inputRef} type="file"
+      onChange={(event) => {
+        const file = event.target.files?.[0];
+        if (file) void install.mutate(file);
+        event.currentTarget.value = "";
+      }} />
+    <button className="settings-action" disabled={install.isPending}
+      onClick={() => inputRef.current?.click()} type="button">
+      {install.isPending ? <LoaderCircle aria-hidden="true" className="spin" size={15} /> : <PackageSearch aria-hidden="true" size={15} />}
+      {t("安装 Skill 包", "Install Skill package")}
+    </button>
+    {message && <span className="projection-placeholder">{message}</span>}
+    {install.error && <span className="inline-warning">{install.error instanceof Error ? install.error.message : t("安装失败", "Install failed")}</span>}
+  </div>;
 }
 
 export function SettingsView({
@@ -158,9 +196,10 @@ export function SettingsView({
           <button onClick={onOpenModels} type="button">
             <Cpu aria-hidden="true" size={16} /><span>{t("模型与配置", "Models and providers")}</span>
           </button>
-          <button disabled={!desktop} onClick={onOpenSkills} type="button">
+          <button onClick={onOpenSkills} type="button">
             <PackageSearch aria-hidden="true" size={16} /><span>{t("Skill 包", "Skill packages")}</span>
           </button>
+          {!desktop && client.hasSkillInstallation && <WebSkillInstall client={client} />}
         </nav>
       </aside>
       <SidebarResizeHandle onChange={resizeSidebar} value={sidebarWidth} />


### PR DESCRIPTION
## 背景

盘点里剩余的 P1/P2/P3 全部是纯 Web 改动（后端端点与视图已存在）。本 PR 一次性补齐。

## 本次改动

- **P1 价格快照**：模型面板新增"价格快照"区——列表展示导入历史（ID/来源/币种/条目数/指纹），control 门控的导入（粘贴 `price_snapshot.v1` 文档）；客户端新增 `listPriceSnapshots`/`importPriceSnapshot` + 严格解析器。
- **P1 Docker 沙箱**：新增"沙箱"tab——状态查询（按准入 ID）、Manifest JSON 粘贴准入、启动/取消（control 门控、显式确认）；客户端新增 `getDockerSandboxStatus`/`admitDockerSandbox`/`startDockerSandbox`/`cancelDockerSandbox`。
- **P2 Skill 安装（Web）**：非 desktop 环境启用 Skill 包安装（文件选择 → base64 → `installSkillPackage`），桌面环境仍走原生桥。
- **P3 字段级渲染**：
  - 委派：准入上限（max_children/max_turns_per_child/max_tokens_per_child）与停止原因；
  - fan-out：范围/分片数/单分片输出上限/停止原因；分片表新增尝试/输入/输出/错误列；
  - 操作收据：retry_strategy / recovery_action；
  - 证据清单：instruction_authorized 徽标。

## 验证

- Web typecheck / vitest（235 用例）/ build 全绿；纯 Web 改动，Go 零变更。

## 安全边界与非目标

- Docker 沙箱与价格导入都是 control token + 显式确认的窄操作，UI 不自行提权；readonly fan-out 与沙箱权限模型不变。
- Run 概览的 `RunView.Budget` 渲染与"run 创建设预算"（需要后端请求形状变更）不在本 PR，留作后续。

## 依赖

栈于 #70（child-task 审阅控制面）顶端，随 #68 → #70 链合并后评审。