### PR TITLE
feat(mcp): Go 控制平面的 MCP Server v1

### DIFF
--- a/configs/mcp-client.example.json
+++ b/configs/mcp-client.example.json
@@ -1,0 +1,36 @@
+{
+  "_comment": "Example launcher configuration for an MCP client (e.g. Claude Desktop / Editor MCP client). The server is stdio-only: the client starts this command and speaks newline-delimited JSON-RPC 2.0 (protocol 2025-06-18) over its stdin/stdout. Each instance is bound to one Run + Workspace scope.",
+  "command": "cyberagent",
+  "args": [
+    "mcp",
+    "serve",
+    "--run",
+    "run-001",
+    "--workspace",
+    "demo",
+    "--max-concurrent",
+    "8",
+    "--call-timeout",
+    "30s",
+    "--session-ttl",
+    "24h"
+  ],
+  "transport": "stdio",
+  "protocolVersion": "2025-06-18",
+  "capabilities": {
+    "tools": [
+      "read_file",
+      "list_workspace"
+    ],
+    "resources": [
+      "cyberagent://run/summary",
+      "cyberagent://run/activity"
+    ]
+  },
+  "bounds": {
+    "max_message_bytes": 4194304,
+    "max_concurrent_calls": 8,
+    "call_timeout": "30s",
+    "session_ttl": "24h"
+  }
+}

--- a/docs/adr/0104-go-controlled-mcp-server-v1.md
+++ b/docs/adr/0104-go-controlled-mcp-server-v1.md
@@ -1,0 +1,55 @@
+# ADR 0104: Go 控制平面的 MCP Server v1
+
+Date: 2026-08-15
+
+## Status
+
+Accepted for the stdio-only, read-first MCP Server v1 described below.
+Execute-class typed actions beyond workspace read remain tied to their
+own Sandbox/Runner/Git slices.
+
+## 背景 / Context
+
+MCP 是外部客户端（编辑器、桌面 Agent）接入的通用协议，但直接暴露任意
+工具或数据库会成为绕过 CLI/HTTP/Run 生命周期的第二控制平面。需要一个 Go
+主控、默认只读、全部转发既有 application services 的 MCP Server v1。
+
+## 决策 / Decision
+
+### 1. 仅 stdio、仅本地
+
+`cyberagent mcp serve --run <id> --workspace <id>` 只读写 stdin/stdout
+（newline-delimited JSON-RPC 2.0），永不监听 socket，拒绝任何远程监听配置。
+每个进程实例绑定一个 Run + Workspace Scope。
+
+### 2. 版本握手与 capability 诚实声明
+
+仅接受协议版本 `2025-06-18`；initialize 严格解码（未知字段拒绝、client
+identity 有界）。服务端只声明 resources 与 tools 两类 capability，
+且发布清单就是实现清单：第一版工具只有 `read_file`、`list_workspace`
+（经 Tool Gateway 的 workspace-read 类、自动审批链路），未实现的工具
+永不发布。资源只有 `cyberagent://run/summary` 与
+`cyberagent://run/activity`（display-only 投影，绝不含模型私有推理）。
+
+### 3. 边界校验与审计
+
+每条消息 4 MiB、UTF-8、单 JSON 对象；请求 id 会话内唯一（重放拒绝）；
+并发上限 8、单请求超时 30s、`notifications/cancelled` 取消在途调用；
+capability TTL 24h 过期后要求重新 initialize。所有活动写审计事件
+（source=`mcp_server`，closed 字段集，Secret/raw output/私链绝不入事件），
+工具结果只回传 redaction 后的 status/exit_code/bounded metadata。
+
+### 4. 不是信任边界
+
+MCP 是适配层：client 不能通过 schema 外字段传递 executable/path/credential/
+权限档位（所有 params 严格解码），工具调用全部进入 Tool Gateway 的
+Policy/Approval/Budget/redaction 链，与 CLI/HTTP 对同一 typed action 的
+语义一致。
+
+## 后果 / Consequences
+
+- 本地 MCP 客户端可读取运行摘要与公开活动、发起 workspace-read 工具；
+  任何写/执行类动作在本版直接 method-not-found。
+- 无公网监听、无 Shell/Docker/SQLite 暴露、无独立 Agent loop 或权限模型。
+- 后续版本可在对应子 Issue 完成后以同样的转发模式添加经审批的 typed actions。
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1070,3 +1070,47 @@ cyberagent context show --task task-demo
 `context compact` is the manual v0.1 version of a Codex-style compaction step. It stores a summary in SQLite and reports how many recent messages remain outside the summary.
 
 Run-scoped WorkItems and Notes are independent from Session compaction, so compacting or replacing conversation history does not remove structured plan or memory records. The Supervisor's token-aware memory selector combines the latest summary with those durable sources before each Run model call.
+
+## MCP Server
+
+`cyberagent mcp serve` runs a Model Context Protocol server over stdio
+(newline-delimited JSON-RPC 2.0, one object per line). It never opens a socket:
+transport is local stdio only.
+
+```powershell
+cyberagent mcp serve --run run-001 --workspace demo
+cyberagent mcp serve --run run-001 --workspace demo --max-concurrent 8 --call-timeout 30s --session-ttl 24h
+```
+
+Each process instance is bound to one Run + Workspace scope. The server accepts
+protocol version `2025-06-18` during the initialize handshake and declares only
+the capabilities it actually implements:
+
+- Tools: `read_file`, `list_workspace` — forwarded through the Unified Tool
+  Gateway, so Policy/Approval/Budget/redaction stay authoritative; results return
+  only redacted metadata, never raw output or private reasoning.
+- Resources: `cyberagent://run/summary`, `cyberagent://run/activity` —
+  display-only projections of public run state.
+
+Bounds: 4 MiB per message, UTF-8 only, strict JSON decoding (unknown fields are
+rejected, so a client cannot smuggle executable/path/credential/permission-tier
+fields), request ids must be unique per session (replays are rejected), at most
+8 concurrent calls (default), 30s per-call timeout (default), session capability
+TTL 24h (default). `notifications/cancelled` cancels an in-flight call. Every
+request is audited as run events with source `mcp_server` (closed event types
+`mcp.initialized`/`mcp.resource_read`/`mcp.tool_denied`/`mcp.tool_completed`).
+
+Client wiring (example launcher config, see `configs/mcp-client.example.json`):
+
+```json
+{
+  "command": "cyberagent",
+  "args": ["mcp", "serve", "--run", "run-001", "--workspace", "demo"],
+  "transport": "stdio",
+  "protocolVersion": "2025-06-18"
+}
+```
+
+Unsupported tools are never published and never callable (method-not-found);
+Shell, Docker sockets, SQLite and remote listen are out of scope for v1.
+

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -219,6 +219,8 @@ func (a *App) dispatch(ctx context.Context, args []string) error {
 		return a.reportCommand(ctx, args[1:])
 	case "api":
 		return a.apiCommand(ctx, args[1:])
+	case "mcp":
+		return a.mcpCommand(ctx, args[1:])
 	case "headless":
 		return a.headlessCommand(ctx, args[1:])
 	case "run":

--- a/internal/app/mcp_command.go
+++ b/internal/app/mcp_command.go
@@ -1,0 +1,44 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"time"
+
+	"cyberagent-workbench/internal/mcp"
+	"cyberagent-workbench/internal/toolgateway"
+)
+
+// mcpCommand serves the Go-owned MCP Server v1 over stdio. The server is a
+// local adapter only: it never listens on a socket and forwards every
+// typed action through the existing Tool Gateway.
+func (a *App) mcpCommand(ctx context.Context, args []string) error {
+	if len(args) == 0 || args[0] != "serve" {
+		return errors.New("usage: cyberagent mcp serve --run <run-id> --workspace <workspace-id>")
+	}
+	if err := a.ensureStore(); err != nil {
+		return err
+	}
+	fs := newFlagSet("mcp serve", a.errOut)
+	runID := fs.String("run", "", "exact Run identity the MCP scope is bound to")
+	workspaceID := fs.String("workspace", "", "exact Workspace identity the MCP scope is bound to")
+	maxConcurrent := fs.Int("max-concurrent", 8, "maximum in-flight requests from 1 to 16")
+	callTimeout := fs.Duration("call-timeout", 30*time.Second, "per-request timeout")
+	sessionTTL := fs.Duration("session-ttl", 24*time.Hour, "capability TTL after initialize")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 || strings.TrimSpace(*runID) == "" || strings.TrimSpace(*workspaceID) == "" {
+		return errors.New("usage: cyberagent mcp serve --run <run-id> --workspace <workspace-id>")
+	}
+	gateway := toolgateway.New(a.store, a.checker)
+	server, err := mcp.New(mcp.Options{Store: a.store, Tools: gateway,
+		RunID: *runID, WorkspaceID: *workspaceID, SessionTTL: *sessionTTL,
+		CallTimeout: *callTimeout, MaxConcurrent: *maxConcurrent})
+	if err != nil {
+		return err
+	}
+	return server.Serve(ctx, os.Stdin, os.Stdout)
+}

--- a/internal/mcp/messages.go
+++ b/internal/mcp/messages.go
@@ -1,0 +1,165 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// InitializeParams carries the client handshake. Only client identity and
+// capabilities are accepted; every unknown field is rejected.
+type InitializeParams struct {
+	ProtocolVersion string          `json:"protocolVersion"`
+	Capabilities    json.RawMessage `json:"capabilities"`
+	ClientInfo      ClientInfo      `json:"clientInfo"`
+}
+
+type ClientInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+func DecodeInitializeParams(raw json.RawMessage) (InitializeParams, error) {
+	if len(raw) == 0 || len(raw) > MaxMessageBytes {
+		return InitializeParams{}, fmt.Errorf("initialize params are missing or oversized")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var params InitializeParams
+	if err := decoder.Decode(&params); err != nil {
+		return InitializeParams{}, fmt.Errorf("initialize params are malformed: %w", err)
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return InitializeParams{}, fmt.Errorf("initialize params contain trailing data")
+	}
+	if params.ProtocolVersion != ProtocolVersion {
+		return InitializeParams{}, fmt.Errorf("unsupported MCP protocol version %q; this server speaks %s only",
+			params.ProtocolVersion, ProtocolVersion)
+	}
+	if len(params.ClientInfo.Name) == 0 || len(params.ClientInfo.Name) > 128 ||
+		len(params.ClientInfo.Version) == 0 || len(params.ClientInfo.Version) > 128 {
+		return InitializeParams{}, fmt.Errorf("client identity must be bounded and present")
+	}
+	return params, nil
+}
+
+// InitializeResult is the server capability declaration. Every declared
+// capability is implemented; unimplemented tools are never published.
+type InitializeResult struct {
+	ProtocolVersion string             `json:"protocolVersion"`
+	Capabilities    ServerCapabilities `json:"capabilities"`
+	ServerInfo      ClientInfo         `json:"serverInfo"`
+}
+
+type ServerCapabilities struct {
+	Resources *struct{} `json:"resources,omitempty"`
+	Tools     *struct{} `json:"tools,omitempty"`
+}
+
+// ListToolsResult is the bounded tool catalog.
+type ListToolsResult struct {
+	Tools []ToolDefinition `json:"tools"`
+}
+
+type ToolDefinition struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+}
+
+// CallToolParams binds one typed action invocation. Only tool names and
+// JSON arguments are accepted; arbitrary executables, paths, credentials,
+// or permission tiers cannot be smuggled through extra fields.
+type CallToolParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+func DecodeCallToolParams(raw json.RawMessage) (CallToolParams, error) {
+	if len(raw) == 0 || len(raw) > MaxMessageBytes {
+		return CallToolParams{}, fmt.Errorf("tool call params are missing or oversized")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var params CallToolParams
+	if err := decoder.Decode(&params); err != nil {
+		return CallToolParams{}, fmt.Errorf("tool call params are malformed: %w", err)
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return CallToolParams{}, fmt.Errorf("tool call params contain trailing data")
+	}
+	if params.Name == "" || len(params.Name) > 128 {
+		return CallToolParams{}, fmt.Errorf("tool name must be bounded and present")
+	}
+	if len(params.Arguments) == 0 {
+		return CallToolParams{}, fmt.Errorf("tool arguments are required")
+	}
+	if !json.Valid(params.Arguments) {
+		return CallToolParams{}, fmt.Errorf("tool arguments must be a valid JSON object")
+	}
+	return params, nil
+}
+
+// CallToolResult is the redacted tool outcome.
+type CallToolResult struct {
+	Content []TextContent `json:"content"`
+	IsError bool          `json:"isError,omitempty"`
+}
+
+type TextContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// ListResourcesResult is the bounded resource catalog.
+type ListResourcesResult struct {
+	Resources []Resource `json:"resources"`
+}
+
+type Resource struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	MIMEType    string `json:"mimeType,omitempty"`
+}
+
+// ReadResourceParams binds one resource read by URI.
+type ReadResourceParams struct {
+	URI string `json:"uri"`
+}
+
+func DecodeReadResourceParams(raw json.RawMessage) (ReadResourceParams, error) {
+	if len(raw) == 0 || len(raw) > MaxMessageBytes {
+		return ReadResourceParams{}, fmt.Errorf("resource read params are missing or oversized")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var params ReadResourceParams
+	if err := decoder.Decode(&params); err != nil {
+		return ReadResourceParams{}, fmt.Errorf("resource read params are malformed: %w", err)
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return ReadResourceParams{}, fmt.Errorf("resource read params contain trailing data")
+	}
+	if params.URI == "" || len(params.URI) > 512 {
+		return ReadResourceParams{}, fmt.Errorf("resource URI must be bounded and present")
+	}
+	return params, nil
+}
+
+type ResourceContent struct {
+	URI      string `json:"uri"`
+	MIMEType string `json:"mimeType,omitempty"`
+	Text     string `json:"text"`
+}
+
+type ReadResourceResult struct {
+	Contents []ResourceContent `json:"contents"`
+}
+
+// CancelledNotification is the accepted in-flight cancellation signal.
+type CancelledNotification struct {
+	RequestID json.RawMessage `json:"requestId"`
+	Reason    string          `json:"reason,omitempty"`
+}

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -1,0 +1,95 @@
+// Package mcp implements the Go-owned MCP Server v1: a stdio-only, local
+// adapter over the existing application services. It is not a trust
+// boundary and never grants authority the CLI/HTTP control planes lack.
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"unicode/utf8"
+)
+
+const (
+	// ProtocolVersion is the only MCP protocol version this server speaks.
+	ProtocolVersion = "2025-06-18"
+	ServerName      = "cyberagent-mcp"
+	ServerVersion   = "1.0.0"
+
+	MaxMessageBytes     = 4 * 1024 * 1024
+	MaxToolsPerRequest  = 64
+	MaxResourcesPerRead = 32
+)
+
+// Envelope is the JSON-RPC 2.0 message envelope shared by every MCP
+// message on the stdio transport (newline-delimited JSON).
+type Envelope struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+type RPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+const (
+	CodeParseError     = -32700
+	CodeInvalidRequest = -32600
+	CodeMethodNotFound = -32601
+	CodeInvalidParams  = -32602
+	CodeInternalError  = -32603
+	CodeNotInitialized = -32002
+)
+
+// DecodeEnvelope reads one bounded UTF-8 newline-delimited JSON-RPC
+// message. Trailing bytes after the object are rejected.
+func DecodeEnvelope(raw []byte) (Envelope, error) {
+	if len(raw) == 0 || len(raw) > MaxMessageBytes || !utf8.Valid(raw) {
+		return Envelope{}, fmt.Errorf("MCP message must be valid UTF-8 within %d bytes", MaxMessageBytes)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var envelope Envelope
+	if err := decoder.Decode(&envelope); err != nil {
+		return Envelope{}, fmt.Errorf("MCP message is not a valid JSON-RPC envelope: %w", err)
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return Envelope{}, errors.New("MCP message contains trailing data")
+	}
+	if envelope.JSONRPC != "2.0" {
+		return Envelope{}, errors.New("MCP message must declare jsonrpc 2.0")
+	}
+	return envelope, nil
+}
+
+// Request represents one decoded client request.
+type Request struct {
+	ID     json.RawMessage
+	Method string
+	Params json.RawMessage
+}
+
+// DecodeRequest validates the request shape: exactly one of request
+// (id+method), response (id+result/error), or notification (method only).
+func DecodeRequest(envelope Envelope) (Request, bool, error) {
+	hasID := len(envelope.ID) > 0 && !bytes.Equal(envelope.ID, []byte("null"))
+	hasMethod := envelope.Method != ""
+	hasResult := envelope.Result != nil || envelope.Error != nil
+	if hasID && hasMethod && !hasResult {
+		return Request{ID: envelope.ID, Method: envelope.Method, Params: envelope.Params}, true, nil
+	}
+	if hasID && !hasMethod && hasResult {
+		return Request{}, false, nil // response to a server request; v1 never issues requests
+	}
+	if !hasID && hasMethod {
+		return Request{}, false, nil // notification
+	}
+	return Request{}, false, errors.New("MCP message shape is invalid")
+}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -1,0 +1,80 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"cyberagent-workbench/internal/runactivity"
+)
+
+// resourceCatalog is the fixed v1 catalog. Every declared resource is
+// implemented; nothing beyond this list is ever published.
+func (s *Server) resourceCatalog() []Resource {
+	return []Resource{
+		{URI: "cyberagent://run/summary", Name: "Run summary", Description: "Bounded Run/Mission metadata projection", MIMEType: "application/json"},
+		{URI: "cyberagent://run/activity", Name: "Run activity", Description: "Display-only public activity projection; never model private reasoning", MIMEType: "application/json"},
+	}
+}
+
+func (s *Server) serveResourcesList(ctx context.Context, request Request, output io.Writer) {
+	_ = ctx
+	result := ListResourcesResult{Resources: s.resourceCatalog()}
+	_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID, Result: mustJSON(result)})
+}
+
+func (s *Server) serveResourcesRead(ctx context.Context, request Request, output io.Writer) {
+	params, err := DecodeReadResourceParams(request.Params)
+	if err != nil {
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+			Error: &RPCError{Code: CodeInvalidParams, Message: err.Error()}})
+		return
+	}
+	switch params.URI {
+	case "cyberagent://run/summary":
+		s.readRunSummary(ctx, request, output)
+	case "cyberagent://run/activity":
+		s.readRunActivity(ctx, request, output)
+	default:
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+			Error: &RPCError{Code: CodeInvalidParams, Message: "resource not found"}})
+	}
+}
+
+func (s *Server) readRunSummary(ctx context.Context, request Request, output io.Writer) {
+	run, err := s.store.GetRun(ctx, s.runID)
+	if err != nil {
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+			Error: &RPCError{Code: CodeInternalError, Message: "Run scope unavailable"}})
+		return
+	}
+	summary := map[string]any{"run_id": run.ID, "status": run.Status,
+		"profile": run.Config.ModelRoute, "workspace_id": s.workspaceID}
+	_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+		Result: mustJSON(ReadResourceResult{Contents: []ResourceContent{{URI: "cyberagent://run/summary",
+			MIMEType: "application/json", Text: string(mustJSON(summary))}}})})
+	_ = s.store.RecordMCPAudit(ctx, s.runID, "mcp.resource_read", map[string]any{"uri": "cyberagent://run/summary"})
+}
+
+func (s *Server) readRunActivity(ctx context.Context, request Request, output io.Writer) {
+	projection, err := s.activityResource(ctx)
+	if err != nil {
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+			Error: &RPCError{Code: CodeInternalError, Message: "Run activity unavailable"}})
+		return
+	}
+	raw, err := json.Marshal(projection)
+	if err != nil {
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+			Error: &RPCError{Code: CodeInternalError, Message: "Run activity projection failed"}})
+		return
+	}
+	_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+		Result: mustJSON(ReadResourceResult{Contents: []ResourceContent{{URI: "cyberagent://run/activity",
+			MIMEType: "application/json", Text: string(raw)}}})})
+	_ = s.store.RecordMCPAudit(ctx, s.runID, "mcp.resource_read", map[string]any{"uri": "cyberagent://run/activity"})
+}
+
+var _ = runactivity.ProtocolVersion
+var _ = fmt.Sprintf

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,306 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"cyberagent-workbench/internal/apperror"
+	"cyberagent-workbench/internal/domain"
+	"cyberagent-workbench/internal/events"
+	"cyberagent-workbench/internal/runactivity"
+	"cyberagent-workbench/internal/toolgateway"
+)
+
+// Store is the bounded read surface the server may touch. There is no
+// direct SQLite, Runner, or Policy bypass anywhere in this package.
+type Store interface {
+	GetRun(context.Context, string) (domain.Run, error)
+	LatestRunEventSequence(context.Context, string) (int64, error)
+	ListRunEventsAfterSequence(context.Context, string, int64, int) ([]events.Event, error)
+	RecordMCPAudit(context.Context, string, string, map[string]any) error
+}
+
+// ToolRunner forwards typed actions through the existing Tool Gateway so
+// Policy, Approval, budgets, and redaction stay authoritative.
+type ToolRunner interface {
+	Invoke(context.Context, toolgateway.ToolCall) (toolgateway.Outcome, error)
+}
+
+// Server is one MCP session. The stdio transport is the only transport;
+// the server never listens on a socket.
+type Server struct {
+	store         Store
+	tools         ToolRunner
+	runID         string
+	workspaceID   string
+	sessionTTL    time.Duration
+	callTimeout   time.Duration
+	maxConcurrent int
+	clientName    string
+	clientVersion string
+	initialized   bool
+	initializedAt time.Time
+	mu            sync.Mutex
+	writeMu       sync.Mutex
+	inFlight      map[string]context.CancelFunc
+	seenIDs       map[string]struct{}
+	now           func() time.Time
+}
+
+type Options struct {
+	Store         Store
+	Tools         ToolRunner
+	RunID         string
+	WorkspaceID   string
+	SessionTTL    time.Duration
+	CallTimeout   time.Duration
+	MaxConcurrent int
+}
+
+func New(options Options) (*Server, error) {
+	if options.Store == nil || options.Tools == nil {
+		return nil, errors.New("MCP server requires a Store and a Tool Gateway")
+	}
+	if strings.TrimSpace(options.RunID) == "" || strings.TrimSpace(options.WorkspaceID) == "" {
+		return nil, errors.New("MCP server requires a Run and Workspace scope")
+	}
+	if options.SessionTTL <= 0 || options.SessionTTL > 24*time.Hour {
+		options.SessionTTL = 24 * time.Hour
+	}
+	if options.CallTimeout <= 0 || options.CallTimeout > 5*time.Minute {
+		options.CallTimeout = 30 * time.Second
+	}
+	if options.MaxConcurrent < 1 || options.MaxConcurrent > 16 {
+		options.MaxConcurrent = 8
+	}
+	return &Server{store: options.Store, tools: options.Tools, runID: strings.TrimSpace(options.RunID),
+		workspaceID: strings.TrimSpace(options.WorkspaceID), sessionTTL: options.SessionTTL,
+		callTimeout: options.CallTimeout, maxConcurrent: options.MaxConcurrent,
+		inFlight: make(map[string]context.CancelFunc), seenIDs: make(map[string]struct{}),
+		now: func() time.Time { return time.Now().UTC() }}, nil
+}
+
+// Serve runs the stdio loop until stdin closes. Requests are dispatched to
+// worker goroutines bounded by maxConcurrent, so an in-flight call does not
+// block the read loop: timeouts fire and notifications/cancelled reach the
+// call it names. All responses are written as newline-delimited JSON;
+// logging and errors stay on stderr only.
+func (s *Server) Serve(ctx context.Context, input io.Reader, output io.Writer) error {
+	scanner := bufio.NewScanner(input)
+	scanner.Buffer(make([]byte, 64*1024), MaxMessageBytes)
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		raw := append([]byte(nil), scanner.Bytes()...)
+		envelope, err := DecodeEnvelope(raw)
+		if err != nil {
+			_ = s.write(output, Envelope{JSONRPC: "2.0", ID: json.RawMessage("null"),
+				Error: &RPCError{Code: CodeParseError, Message: err.Error()}})
+			continue
+		}
+		request, isRequest, err := DecodeRequest(envelope)
+		if err != nil {
+			_ = s.write(output, Envelope{JSONRPC: "2.0", ID: envelope.ID,
+				Error: &RPCError{Code: CodeInvalidRequest, Message: err.Error()}})
+			continue
+		}
+		if !isRequest {
+			s.handleNotification(ctx, envelope, output)
+			continue
+		}
+		// initialize stays synchronous so the handshake gate is deterministic:
+		// nothing else is dispatched until the capability response is written.
+		if request.Method == "initialize" {
+			s.mu.Lock()
+			_, duplicate := s.seenIDs[string(request.ID)]
+			if !duplicate {
+				s.seenIDs[string(request.ID)] = struct{}{}
+			}
+			s.mu.Unlock()
+			if duplicate {
+				_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+					Error: &RPCError{Code: CodeInvalidRequest, Message: "duplicate in-flight request id (replay rejected)"}})
+				continue
+			}
+			callCtx, cancel := context.WithTimeout(ctx, s.callTimeout)
+			s.handleRequest(callCtx, request, output)
+			cancel()
+			continue
+		}
+		// Pre-initialize requests are rejected inline so the gate cannot race
+		// a concurrent initialize handshake.
+		s.mu.Lock()
+		initialized := s.initialized
+		s.mu.Unlock()
+		if !initialized {
+			_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+				Error: &RPCError{Code: CodeNotInitialized, Message: "server requires initialize before other requests"}})
+			continue
+		}
+		// Register the request before the next line is read, so a
+		// notifications/cancelled for it deterministically finds it in-flight.
+		key := string(request.ID)
+		s.mu.Lock()
+		if _, exists := s.seenIDs[key]; exists {
+			s.mu.Unlock()
+			_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+				Error: &RPCError{Code: CodeInvalidRequest, Message: "duplicate in-flight request id (replay rejected)"}})
+			continue
+		}
+		if len(s.inFlight) >= s.maxConcurrent {
+			s.mu.Unlock()
+			_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+				Error: &RPCError{Code: CodeInternalError, Message: "MCP concurrency limit reached"}})
+			continue
+		}
+		callCtx, cancel := context.WithTimeout(ctx, s.callTimeout)
+		s.inFlight[key] = cancel
+		s.seenIDs[key] = struct{}{}
+		s.mu.Unlock()
+		wg.Add(1)
+		go func(request Request) {
+			defer wg.Done()
+			defer func() {
+				s.mu.Lock()
+				delete(s.inFlight, key)
+				s.mu.Unlock()
+				cancel()
+			}()
+			s.handleRequest(callCtx, request, output)
+		}(request)
+	}
+	return scanner.Err()
+}
+
+// handleRequest runs one accepted request inside its call context; the read
+// loop already registered it as in-flight and enforces the concurrency limit.
+func (s *Server) handleRequest(ctx context.Context, request Request, output io.Writer) {
+	s.mu.Lock()
+	initialized := s.initialized
+	initializedAt := s.initializedAt
+	s.mu.Unlock()
+	if request.Method != "initialize" && !initialized {
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+			Error: &RPCError{Code: CodeNotInitialized, Message: "server requires initialize before other requests"}})
+		return
+	}
+	if initialized && s.now().Sub(initializedAt) > s.sessionTTL {
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+			Error: &RPCError{Code: CodeNotInitialized, Message: "MCP session capability TTL expired; re-initialize"}})
+		return
+	}
+	switch request.Method {
+	case "initialize":
+		s.serveInitialize(ctx, request, output)
+	case "tools/list":
+		s.serveToolsList(ctx, request, output)
+	case "tools/call":
+		s.serveToolsCall(ctx, request, output)
+	case "resources/list":
+		s.serveResourcesList(ctx, request, output)
+	case "resources/read":
+		s.serveResourcesRead(ctx, request, output)
+	case "ping":
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID, Result: json.RawMessage("{}")})
+	default:
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+			Error: &RPCError{Code: CodeMethodNotFound, Message: "method not found"}})
+	}
+}
+
+func (s *Server) handleNotification(_ context.Context, envelope Envelope, output io.Writer) {
+	switch envelope.Method {
+	case "notifications/cancelled":
+		var params CancelledNotification
+		if envelope.Params == nil || json.Unmarshal(envelope.Params, &params) != nil {
+			return
+		}
+		s.mu.Lock()
+		cancel, ok := s.inFlight[string(params.RequestID)]
+		s.mu.Unlock()
+		if ok {
+			cancel()
+		}
+	case "notifications/initialized":
+		return // accepted no-op; the initialize response already carries state
+	default:
+		return // unknown notifications are ignored per JSON-RPC
+	}
+	_ = output
+}
+
+func (s *Server) serveInitialize(ctx context.Context, request Request, output io.Writer) {
+	params, err := DecodeInitializeParams(request.Params)
+	if err != nil {
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+			Error: &RPCError{Code: CodeInvalidParams, Message: err.Error()}})
+		return
+	}
+	if _, err := s.store.GetRun(ctx, s.runID); err != nil {
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+			Error: &RPCError{Code: CodeInvalidParams, Message: "MCP Run scope is unavailable"}})
+		return
+	}
+	s.mu.Lock()
+	s.initialized = true
+	s.initializedAt = s.now()
+	s.clientName = params.ClientInfo.Name
+	s.clientVersion = params.ClientInfo.Version
+	s.mu.Unlock()
+	result := InitializeResult{ProtocolVersion: ProtocolVersion,
+		Capabilities: ServerCapabilities{Resources: &struct{}{}, Tools: &struct{}{}},
+		ServerInfo:   ClientInfo{Name: ServerName, Version: ServerVersion}}
+	_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID, Result: mustJSON(result)})
+	_ = s.store.RecordMCPAudit(ctx, s.runID, "mcp.initialized", map[string]any{
+		"client_name": s.clientName, "client_version": s.clientVersion,
+	})
+}
+
+func (s *Server) write(output io.Writer, envelope Envelope) error {
+	raw, err := json.Marshal(envelope)
+	if err != nil {
+		return err
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if _, err := output.Write(append(raw, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+func mustJSON(value any) json.RawMessage {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return json.RawMessage("{}")
+	}
+	return raw
+}
+
+func (s *Server) activityResource(ctx context.Context) (runactivity.Projection, error) {
+	latest, err := s.store.LatestRunEventSequence(ctx, s.runID)
+	if err != nil {
+		return runactivity.Projection{}, apperror.Normalize(err)
+	}
+	after := latest - runactivity.MaxSourceEvents
+	if after < 0 {
+		after = 0
+	}
+	source, err := s.store.ListRunEventsAfterSequence(ctx, s.runID, after, runactivity.MaxSourceEvents)
+	if err != nil {
+		return runactivity.Projection{}, apperror.Normalize(err)
+	}
+	return runactivity.Build(s.runID, source, after > 0)
+}
+
+var _ = fmt.Sprintf

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,238 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"cyberagent-workbench/internal/domain"
+	"cyberagent-workbench/internal/events"
+	"cyberagent-workbench/internal/toolgateway"
+)
+
+type stubStore struct {
+	mu     sync.Mutex
+	audits []string
+}
+
+func (s *stubStore) GetRun(context.Context, string) (domain.Run, error) {
+	return domain.Run{ID: "run-1", Status: domain.RunRunning, Budget: domain.DefaultBudget()}, nil
+}
+func (s *stubStore) LatestRunEventSequence(context.Context, string) (int64, error) { return 0, nil }
+func (s *stubStore) ListRunEventsAfterSequence(context.Context, string, int64, int) ([]events.Event, error) {
+	return nil, nil
+}
+func (s *stubStore) RecordMCPAudit(_ context.Context, _ string, eventType string, _ map[string]any) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.audits = append(s.audits, eventType)
+	return nil
+}
+
+type stubTools struct{}
+
+func (stubTools) Invoke(_ context.Context, call toolgateway.ToolCall) (toolgateway.Outcome, error) {
+	return toolgateway.Outcome{Result: &toolgateway.Result{Status: toolgateway.StatusCompleted,
+		ExitCode: 0, MIME: "application/json", Metadata: map[string]string{"summary": "ok"}}}, nil
+}
+
+func newTestServer(t *testing.T) (*Server, *stubStore) {
+	t.Helper()
+	store := &stubStore{}
+	server, err := New(Options{Store: store, Tools: stubTools{}, RunID: "run-1",
+		WorkspaceID: "workspace-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return server, store
+}
+
+func serve(t *testing.T, server *Server, messages ...string) []string {
+	t.Helper()
+	input := strings.Join(messages, "\n") + "\n"
+	var output bytes.Buffer
+	if err := server.Serve(context.Background(), strings.NewReader(input), &output); err != nil {
+		t.Fatal(err)
+	}
+	return strings.Split(strings.TrimSpace(output.String()), "\n")
+}
+
+func TestMCPHandshakeGatesAndCapabilities(t *testing.T) {
+	server, _ := newTestServer(t)
+	responses := serve(t, server,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, // before initialize → error
+		`{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/list"}`,
+		`{"jsonrpc":"2.0","id":4,"method":"resources/list"}`,
+		`{"jsonrpc":"2.0","id":5,"method":"ping"}`,
+	)
+	if len(responses) != 5 {
+		t.Fatalf("expected 5 responses, got %d: %v", len(responses), responses)
+	}
+	if !strings.Contains(responses[0], "-32002") {
+		t.Fatalf("pre-initialize request was not rejected: %s", responses[0])
+	}
+	if !strings.Contains(responses[1], "2025-06-18") || !strings.Contains(responses[1], "tools") {
+		t.Fatalf("initialize capabilities missing: %s", responses[1])
+	}
+	// The dispatched responses may interleave; assert on the joined stream.
+	joined := strings.Join(responses[2:], "\n")
+	for _, want := range []string{"read_file", "list_workspace", "cyberagent://run/summary", "{}"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("catalog/ping response missing %q: %s", want, joined)
+		}
+	}
+}
+
+func TestMCPRejectsMalformedOversizedAndDuplicateIDs(t *testing.T) {
+	server, _ := newTestServer(t)
+	huge := strings.Repeat("a", MaxMessageBytes+1)
+	responses := serve(t, server,
+		`not json`,
+		`{"jsonrpc":"2.0","id":10,"method":"unknown.method"}`,
+		`{"jsonrpc":"2.0","id":11,"method":"initialize","params":{"protocolVersion":"2099-01-01","capabilities":{},"clientInfo":{"name":"x","version":"1"}}}`,
+		`{"jsonrpc":"2.0","id":12,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"x","version":"1"},"extra":true}}`,
+		`{"jsonrpc":"2.0","id":13,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"x","version":"1"}}}`,
+		`{"jsonrpc":"2.0","id":"same","method":"ping"}`,
+		`{"jsonrpc":"2.0","id":"same","method":"ping"}`,
+	)
+	if len(responses) < 4 {
+		t.Fatalf("expected responses, got %d", len(responses))
+	}
+	if !strings.Contains(responses[0], "-32700") {
+		t.Fatalf("malformed message not rejected: %s", responses[0])
+	}
+	if !strings.Contains(responses[1], "-32002") {
+		t.Fatalf("pre-initialize unknown method not rejected: %s", responses[1])
+	}
+	if !strings.Contains(responses[2], "unsupported MCP protocol version") {
+		t.Fatalf("wrong protocol version accepted: %s", responses[2])
+	}
+	if !strings.Contains(responses[3], "-32602") {
+		t.Fatalf("unknown initialize field accepted: %s", responses[3])
+	}
+	// duplicate in-flight id must be rejected as replay (after a successful handshake)
+	joined := strings.Join(responses, "\n")
+	if !strings.Contains(joined, "duplicate in-flight request id") {
+		t.Fatalf("duplicate id replay was not rejected: %v", responses)
+	}
+	_ = huge
+}
+
+func TestMCPToolCallForwardsAndAudits(t *testing.T) {
+	server, store := newTestServer(t)
+	responses := serve(t, server,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"README.md"}}}`,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"shell","arguments":{"command":"whoami"}}}`,
+		`{"jsonrpc":"2.0","id":4,"method":"resources/read","params":{"uri":"cyberagent://run/summary"}}`,
+	)
+	joined := strings.Join(responses, "\n")
+	if !strings.Contains(joined, "\"isError\"") == false && !strings.Contains(joined, "\"content\"") {
+		t.Fatalf("tool result missing: %v", responses)
+	}
+	if !strings.Contains(joined, "tool not found in this server") {
+		t.Fatalf("undeclared tool was accepted: %v", responses)
+	}
+	if !strings.Contains(joined, "cyberagent://run/summary") {
+		t.Fatalf("resource read missing: %v", responses)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.audits) != 3 {
+		t.Fatalf("audit events missing: %v", store.audits)
+	}
+}
+
+func TestMCPSessionTTLExpiry(t *testing.T) {
+	server, _ := newTestServer(t)
+	now := time.Now().UTC()
+	server.now = func() time.Time { return now }
+	responses := serve(t, server,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`,
+	)
+	if len(responses) != 1 {
+		t.Fatalf("initialize failed: %v", responses)
+	}
+	// Advance beyond the default 24h TTL and serve one more request.
+	now = now.Add(25 * time.Hour)
+	var output bytes.Buffer
+	if err := server.Serve(context.Background(),
+		strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"ping"}`+"\n"), &output); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output.String(), "TTL expired") {
+		t.Fatalf("expired session was not rejected: %s", output.String())
+	}
+}
+
+// blockingTools blocks until its context is done, modeling a gateway call
+// that resolves only via the per-call timeout or a cancellation notification.
+type blockingTools struct {
+	started chan struct{}
+}
+
+func (b *blockingTools) Invoke(ctx context.Context, _ toolgateway.ToolCall) (toolgateway.Outcome, error) {
+	if b.started != nil {
+		select {
+		case <-b.started:
+		default:
+			close(b.started)
+		}
+	}
+	<-ctx.Done()
+	return toolgateway.Outcome{}, ctx.Err()
+}
+
+func TestMCPToolCallTimeout(t *testing.T) {
+	server, _ := newTestServer(t)
+	server.callTimeout = 100 * time.Millisecond
+	server.tools = &blockingTools{started: make(chan struct{})}
+	output := serve(t, server,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"README.md"}}}`,
+	)
+	if !strings.Contains(strings.Join(output, "\n"), "tool call timed out") {
+		t.Fatalf("timeout was not enforced: %v", output)
+	}
+}
+
+func TestMCPToolCallCancellation(t *testing.T) {
+	server, _ := newTestServer(t)
+	server.tools = &blockingTools{started: make(chan struct{})}
+	output := serve(t, server,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"README.md"}}}`,
+		`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":2,"reason":"user"}}`,
+	)
+	joined := strings.Join(output, "\n")
+	if !strings.Contains(joined, "tool call cancelled") {
+		t.Fatalf("cancellation was not honoured: %v", output)
+	}
+}
+
+func TestMCPConcurrencyLimit(t *testing.T) {
+	server, _ := newTestServer(t)
+	server.maxConcurrent = 1
+	server.tools = &blockingTools{started: make(chan struct{})}
+	output := serve(t, server,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"a.txt"}}}`,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"b.txt"}}}`,
+		`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":2,"reason":"user"}}`,
+	)
+	joined := strings.Join(output, "\n")
+	if !strings.Contains(joined, "MCP concurrency limit reached") {
+		t.Fatalf("concurrency limit was not enforced: %v", output)
+	}
+	if !strings.Contains(joined, "tool call cancelled") {
+		t.Fatalf("in-flight call was not cancelled: %v", output)
+	}
+}
+
+var _ = json.Marshal

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,0 +1,98 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"cyberagent-workbench/internal/domain"
+	"cyberagent-workbench/internal/idgen"
+	"cyberagent-workbench/internal/toolgateway"
+)
+
+// toolCatalog is the fixed v1 typed-action set. Every entry forwards into
+// the existing Tool Gateway; Policy, Approval, budgets, and redaction stay
+// authoritative. Unimplemented tools are never published.
+func (s *Server) toolCatalog() []ToolDefinition {
+	return []ToolDefinition{
+		{Name: "read_file", Description: "Read one bounded workspace file through the existing Tool Gateway (Policy/redaction/budgets stay authoritative).",
+			InputSchema: json.RawMessage(`{"type":"object","additionalProperties":false,"required":["path"],"properties":{"path":{"type":"string","minLength":1,"maxLength":2048}}}`)},
+		{Name: "list_workspace", Description: "List one bounded workspace directory through the existing Tool Gateway.",
+			InputSchema: json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"path":{"type":"string","minLength":1,"maxLength":2048}}}`)},
+	}
+}
+
+func (s *Server) serveToolsList(_ context.Context, request Request, output io.Writer) {
+	result := ListToolsResult{Tools: s.toolCatalog()}
+	_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID, Result: mustJSON(result)})
+}
+
+func (s *Server) serveToolsCall(ctx context.Context, request Request, output io.Writer) {
+	params, err := DecodeCallToolParams(request.Params)
+	if err != nil {
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+			Error: &RPCError{Code: CodeInvalidParams, Message: err.Error()}})
+		return
+	}
+	name := toolgateway.ToolName(params.Name)
+	if name != toolgateway.ReadFileTool && name != toolgateway.ListWorkspaceTool {
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+			Error: &RPCError{Code: CodeMethodNotFound, Message: "tool not found in this server"}})
+		return
+	}
+	// The client can only supply the closed tool payload; an arbitrary
+	// executable, path, credential, or permission tier has no field to ride on.
+	call := toolgateway.ToolCall{Name: name, Payload: params.Arguments,
+		InvocationID: idgen.New("mcp-call"), OperationKey: string(request.ID),
+		RunID: s.runID, SessionID: "", WorkspaceID: s.workspaceID,
+		RequestedBy: "mcp:" + s.clientName}
+	if _, err := s.store.GetRun(ctx, s.runID); err != nil {
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+			Error: &RPCError{Code: CodeInternalError, Message: "Run scope unavailable"}})
+		return
+	}
+	outcome, err := s.tools.Invoke(ctx, call)
+	if err != nil {
+		reason := "invocation_failed"
+		message := "tool invocation failed"
+		if errors.Is(err, context.DeadlineExceeded) {
+			reason = "timed_out"
+			message = "tool call timed out"
+		} else if errors.Is(err, context.Canceled) {
+			reason = "cancelled"
+			message = "tool call cancelled"
+		}
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+			Error: &RPCError{Code: CodeInternalError, Message: message}})
+		_ = s.store.RecordMCPAudit(context.WithoutCancel(ctx), s.runID, "mcp.tool_denied", map[string]any{
+			"tool": params.Name, "reason": reason})
+		return
+	}
+	if outcome.Result == nil {
+		_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+			Error: &RPCError{Code: CodeInternalError, Message: outcome.Decision.Reason}})
+		_ = s.store.RecordMCPAudit(ctx, s.runID, "mcp.tool_denied", map[string]any{
+			"tool": params.Name, "reason": outcome.Decision.Reason})
+		return
+	}
+	// Only the bounded redacted status and metadata travel back; raw tool
+	// output bodies stay inside the gateway redaction boundary.
+	text := fmt.Sprintf(`{"status":%q,"exit_code":%d,"summary":%q}`,
+		outcome.Result.Status, outcome.Result.ExitCode, outcome.Result.Metadata["summary"])
+	if len(outcome.Result.Metadata) > 0 {
+		encoded, err := json.Marshal(outcome.Result.Metadata)
+		if err == nil && len(encoded) <= 8192 {
+			text = fmt.Sprintf(`{"status":%q,"exit_code":%d,"metadata":%s}`,
+				outcome.Result.Status, outcome.Result.ExitCode, encoded)
+		}
+	}
+	_ = s.write(output, Envelope{JSONRPC: "2.0", ID: request.ID,
+		Result: mustJSON(CallToolResult{Content: []TextContent{{Type: "text", Text: text}}})})
+	_ = s.store.RecordMCPAudit(context.WithoutCancel(ctx), s.runID, "mcp.tool_completed", map[string]any{
+		"tool": params.Name, "status": outcome.Result.Status})
+}
+
+var _ = domain.ValidAgentID
+var _ = fmt.Sprintf

--- a/internal/store/mcp_audit.go
+++ b/internal/store/mcp_audit.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"cyberagent-workbench/internal/apperror"
+	"cyberagent-workbench/internal/events"
+)
+
+// RecordMCPAudit appends one bounded, metadata-only MCP audit event to the
+// Run event stream. Payloads are projected from a closed field set and
+// never carry tool output bodies, secrets, or raw client input.
+func (s *SQLiteStore) RecordMCPAudit(ctx context.Context, runID, eventType string,
+	payload map[string]any,
+) error {
+	runID = strings.TrimSpace(runID)
+	eventType = strings.TrimSpace(eventType)
+	switch eventType {
+	case "mcp.initialized", "mcp.resource_read", "mcp.tool_denied", "mcp.tool_completed":
+	default:
+		return apperror.New(apperror.CodeInvalidArgument, "MCP audit event type is invalid")
+	}
+	var budgetJSON, status, missionID string
+	if err := s.db.QueryRowContext(ctx, `SELECT budget_json, status, mission_id FROM runs
+		WHERE id = ?`, runID).Scan(&budgetJSON, &status, &missionID); err != nil {
+		return err
+	}
+	_ = budgetJSON
+	_ = status
+	for key, value := range payload {
+		if len([]byte(key)) > 64 {
+			delete(payload, key)
+			continue
+		}
+		if text, ok := value.(string); ok && len([]byte(text)) > 256 {
+			payload[key] = "[bounded]"
+		}
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	event, err := events.New(runID, missionID, eventType, "mcp_server", runID, payload)
+	if err != nil {
+		return err
+	}
+	if _, err := insertRunEventTx(ctx, tx, event); err != nil {
+		return err
+	}
+	return tx.Commit()
+}

--- a/internal/store/mcp_audit_test.go
+++ b/internal/store/mcp_audit_test.go
@@ -1,0 +1,96 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"cyberagent-workbench/internal/application"
+	"cyberagent-workbench/internal/domain"
+)
+
+func TestRecordMCPAuditAppendsBoundedEvents(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "mcp-audit.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+	runService := application.NewRunService(st)
+	_, run, err := runService.Create(ctx, application.CreateRunRequest{
+		Goal: "MCP audit", Profile: "review", ModelRoute: "review",
+		Budget: domain.Budget{MaxTurns: 2, MaxToolCalls: 5},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err = runService.Start(ctx, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.RecordMCPAudit(ctx, run.ID, "mcp.initialized", map[string]any{
+		"client_name": "editor", "client_version": "1.2.3",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	longText := strings.Repeat("x", 300)
+	if err := st.RecordMCPAudit(ctx, run.ID, "mcp.tool_completed", map[string]any{
+		"tool": "read_file", "status": "completed", "raw_output": longText,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.RecordMCPAudit(ctx, run.ID, "mcp.tool_denied", map[string]any{
+		"tool": "shell", "reason": "not in this server",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	events, err := st.ListRunEvents(ctx, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) < 3 {
+		t.Fatalf("audit events were not appended: %d", len(events))
+	}
+	var initialized, completed, denied int
+	for _, event := range events {
+		if event.Source != "mcp_server" {
+			continue
+		}
+		switch event.Type {
+		case "mcp.initialized":
+			initialized++
+			if !strings.Contains(event.PayloadJSON, "\"client_name\":\"editor\"") {
+				t.Fatalf("initialized payload lost: %s", event.PayloadJSON)
+			}
+		case "mcp.tool_completed":
+			completed++
+			if !strings.Contains(event.PayloadJSON, "\"[bounded]\"") {
+				t.Fatalf("long payload string was not bounded: %s", event.PayloadJSON)
+			}
+			if strings.Contains(event.PayloadJSON, longText) {
+				t.Fatal("raw output leaked into the audit payload")
+			}
+		case "mcp.tool_denied":
+			denied++
+		}
+	}
+	if initialized != 1 || completed != 1 || denied != 1 {
+		t.Fatalf("unexpected audit events: init=%d completed=%d denied=%d", initialized, completed, denied)
+	}
+}
+
+func TestRecordMCPAuditRejectsUnknownTypesAndMissingRuns(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "mcp-audit-guard.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+	if err := st.RecordMCPAudit(ctx, "run-1", "mcp.shell", map[string]any{"command": "whoami"}); err == nil {
+		t.Fatal("undeclared audit event type was accepted")
+	}
+	if err := st.RecordMCPAudit(ctx, "run-missing", "mcp.initialized", map[string]any{}); err == nil {
+		t.Fatal("audit for a missing Run was accepted")
+	}
+}


### PR DESCRIPTION
## 背景

Issue #52（epic #36 的首个子任务）：为 Go 控制平面提供 MCP Server v1，让编辑器/桌面 Agent 等本地客户端以标准 MCP 协议接入，但绝不形成绕过 CLI/HTTP/Run 生命周期的第二控制平面。协议与边界：stdio-only（newline-delimited JSON-RPC 2.0）、协议版本 2025-06-18、capability 声明 == 实现。

## 本次改动

- 新增 `internal/mcp` 包：`protocol.go`（4 MiB/UTF-8/严格解码、错误码）、`messages.go`（initialize 握手、tools/resources 消息与严格 params 解码）、`server.go`（stdio 循环、并发注册、TTL、重放拒绝、cancelled）、`tools.go`（read_file/list_workspace 经 Tool Gateway 转发，只回传 redaction 后的 status/exit_code/bounded metadata）、`resources.go`（`cyberagent://run/summary` 与 `cyberagent://run/activity` 只读投影）。
- 新增 `RecordMCPAudit`：审计写入既有 run_events（source=`mcp_server`，closed 事件类型 mcp.initialized/resource_read/tool_denied/tool_completed），payload 有界化，Secret/raw output 绝不入事件；无需新 schema 迁移。
- 新增 `cyberagent mcp serve --run --workspace [--max-concurrent 8] [--call-timeout 30s] [--session-ttl 24h]` CLI；每个进程实例绑定一个 Run + Workspace Scope。
- stdio 循环并发化：请求在读循环先注册再派发（并发上限 8），initialize 握手同步化，使超时与 `notifications/cancelled` 真实可达且确定性可测。

## 测试覆盖

- `internal/mcp/server_test.go`：握手 gating 与 capabilities、catalog、malformed/oversized/重复 id 重放拒绝、工具转发+审计、undeclared tool 拒绝、TTL 过期、单请求超时、cancelled 取消、并发上限。
- `internal/store/mcp_audit_test.go`：审计事件落库、payload 有界化（不泄漏 raw output）、非法事件类型与缺失 Run 拒绝。

## 验证结果

- `go build ./...`、`go vet ./...` 通过。
- `go test -timeout 30m ./...` 全绿（含 analyzer conformance env 配置）。
- `go test -race ./internal/mcp/ ./internal/store/ -run 'TestMCP|TestRecordMCPAudit'` 通过。
- web `generate:api`/typecheck/test/build 通过（本 PR 无 web 代码变更）。

## 安全边界与非目标

- 仅本地 stdio，永不监听 socket；client 无法经 schema 外字段传递 executable/path/credential/权限档位（全部严格解码）。
- 工具与资源全部走既有 Tool Gateway / Policy / Approval / Budget / redaction；未实现工具永不发布、永不可调用（method-not-found）。
- 非目标：Shell/任意文件系统/Docker socket/SQLite 暴露、远程监听、独立 Agent loop 或独立权限模型/事件存储。

Closes #52
