### PR TITLE
feat(release): 可复现 portable ZIP、SBOM、NOTICE 与校验和

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,0 +1,51 @@
+name: Desktop release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  portable-zip:
+    name: Portable ZIP (SBOM + NOTICE + checksums)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up current Go 1.25 patch
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.x'
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Verify Go module graph is tidy (lockfile drift / undeclared dependency)
+        run: go mod tidy -diff
+
+      - name: Build Desktop (reproducibility check)
+        shell: powershell
+        run: ./scripts/build-desktop.ps1 -VerifyReproducible
+
+      - name: Package portable ZIP (SBOM + NOTICE + SHA-256 + manifest)
+        shell: powershell
+        run: ./scripts/package-portable-zip.ps1
+
+      - name: Upload portable ZIP artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Prayu-portable
+          if-no-files-found: error
+          path: |
+            build/desktop/*.zip
+            build/desktop/SHA256SUMS
+            build/desktop/portable-zip-manifest.json
+            build/desktop/sbom.json
+            build/desktop/NOTICE

--- a/README.md
+++ b/README.md
@@ -157,6 +157,24 @@ open build/desktop/Prayu.app
 
 更多命令与边界见[使用手册](docs/usage.md)。
 
+### 便携 ZIP 下载与验证 / Portable ZIP download and verification
+
+发布候选是未签名的便携 ZIP（`Prayu-portable-<version>-windows-amd64.zip`），包含 `cyberagent-desktop.exe`、操作者预览启动器、`LOCAL-TEST-GUIDE.txt`、`LICENSE`、第三方 `NOTICE`、CycloneDX `sbom.json` 与 `release-metadata.json`。发布件不带 API key、用户数据、缓存、调试日志或源映射。
+
+The release candidate is an unsigned portable ZIP (`Prayu-portable-<version>-windows-amd64.zip`) containing `cyberagent-desktop.exe`, the operator-preview launcher, `LOCAL-TEST-GUIDE.txt`, `LICENSE`, a third-party `NOTICE`, the CycloneDX `sbom.json`, and `release-metadata.json`. It carries no API key, user data, cache, debug log, or source map.
+
+**下载后校验 / Verify after download**（PowerShell）：
+
+```powershell
+# 与 SHA256SUMS 中的条目比对 / compare against SHA256SUMS
+Get-FileHash .\Prayu-portable-v0.1.0-windows-amd64.zip -Algorithm SHA256
+
+# 启动请用启动器，不要直接双击裸 EXE / use the launcher, not the bare EXE
+.\Start-Prayu-Operator-Preview.cmd
+```
+
+**SmartScreen 预期 / SmartScreen expectations**：便携 ZIP 与 EXE 均未签名，Windows SmartScreen 可能提示“未知发布者”。这是未签名候选的预期限制，不是构建缺陷；正式签名发行（MSIX）在另一条发布线完成。The ZIP and EXE are unsigned, so Windows SmartScreen may warn about an unknown publisher. This is the expected limitation of an unsigned candidate, not a build defect; the signed MSIX release is tracked separately.
+
 ## 项目结构
 
 | 路径 | 说明 |

--- a/cmd/releasegen/main.go
+++ b/cmd/releasegen/main.go
@@ -1,0 +1,316 @@
+// Command releasegen emits a deterministic CycloneDX SBOM and a third-party
+// NOTICE for the Go module graph. It is used by the Desktop portable ZIP
+// packaging step; output contains no absolute personal paths, timestamps, or
+// random identifiers beyond a content-derived serial number.
+package main
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type module struct {
+	Path    string
+	Version string
+	Dir     string
+}
+
+type license struct {
+	SPDXID string
+	Text   string
+	Found  bool
+}
+
+var licenseNames = []string{
+	"LICENSE", "LICENSE.txt", "LICENSE.md", "LICENSE.rst",
+	"COPYING", "COPYING.txt", "COPYING.md", "COPYRIGHT",
+	"LICENSE-MIT", "LICENSE-APACHE", "LICENSE-BSD", "UNLICENSE",
+}
+
+// knownLicenses maps a case-insensitive distinguishing substring to an SPDX id.
+var knownLicenses = []struct {
+	Needle string
+	SPDX   string
+}{
+	{"Apache License", "Apache-2.0"},
+	{"Mozilla Public License", "MPL-2.0"},
+	{"Mozilla Public License, v. 2.0", "MPL-2.0"},
+	{"MIT License", "MIT"},
+	{"Permission is hereby granted, free of charge", "MIT"},
+	{"BSD 3-Clause", "BSD-3-Clause"},
+	{"Redistribution and use in source and binary forms", "BSD-3-Clause"},
+	{"BSD 2-Clause", "BSD-2-Clause"},
+	{"ISC License", "ISC"},
+	{"Permission to use, copy, modify, and/or distribute", "ISC"},
+	{"This is free and unencumbered software released into the public domain", "Unlicense"},
+	{"zlib License", "Zlib"},
+	{"Creative Commons Legal Code", "CC0-1.0"},
+	{"DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE", "WTFPL"},
+	// Bare license declarations (last-resort, e.g. README "## License\n\nMIT").
+	{"\nMIT\n", "MIT"},
+	{"\nMIT ", "MIT"},
+}
+
+var zipTimestamp = time.Unix(315532800, 0).UTC() // 1980-01-01, the ZIP DOS minimum
+
+func main() {
+	outDir := flag.String("out", "build/desktop", "output directory for sbom.json and NOTICE")
+	appVersion := flag.String("version", "v0.1.0", "application version for the SBOM component")
+	pkg := flag.String("pkg", "./cmd/cyberagent-desktop", "Go package whose build list the SBOM covers")
+	buildTags := flag.String("tags", "desktop,production,wv2runtime.error", "Go build tags for the dependency list")
+	zipSource := flag.String("zip", "", "if set, create a deterministic ZIP of this directory into --out/<zip-name>")
+	zipName := flag.String("zip-name", "portable.zip", "output ZIP file name")
+	flag.Parse()
+
+	if *zipSource != "" {
+		if err := createDeterministicZip(*zipSource, filepath.Join(*outDir, *zipName)); err != nil {
+			fmt.Fprintln(os.Stderr, "releasegen:", err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stdout, "zip_written: %s\n", filepath.Join(*outDir, *zipName))
+		return
+	}
+
+	modules, err := listModules(*pkg, *buildTags)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "releasegen:", err)
+		os.Exit(1)
+	}
+	sbom, err := buildSBOM(modules, *appVersion)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "releasegen:", err)
+		os.Exit(1)
+	}
+	notice := buildNotice(modules)
+	if err := os.MkdirAll(*outDir, 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, "releasegen:", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(filepath.Join(*outDir, "sbom.json"), sbom, 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "releasegen:", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(filepath.Join(*outDir, "NOTICE"), notice, 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "releasegen:", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stdout, "sbom_written: %s\nnotice_written: %s\nmodules: %d\n",
+		filepath.Join(*outDir, "sbom.json"), filepath.Join(*outDir, "NOTICE"), len(modules))
+}
+
+// listModules returns the distinct third-party modules actually compiled into
+// the target package, using the exact build tags the distributed binary uses.
+// It never runs go mod download, so it never rewrites go.sum.
+func listModules(pkg, buildTags string) ([]module, error) {
+	args := []string{"list", "-deps", "-tags", buildTags,
+		"-f", "{{with .Module}}{{.Path}} {{.Version}} {{.Dir}}{{end}}", pkg}
+	output, err := exec.Command("go", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("go list -deps: %w", err)
+	}
+	seen := map[string]bool{}
+	var modules []module
+	for _, line := range strings.Split(string(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] == "cyberagent-workbench" {
+			continue
+		}
+		key := fields[0] + "@" + fields[1]
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		dir := ""
+		if len(fields) >= 3 {
+			dir = fields[2]
+		}
+		modules = append(modules, module{Path: fields[0], Version: fields[1], Dir: dir})
+	}
+	sort.Slice(modules, func(i, j int) bool { return modules[i].Path < modules[j].Path })
+	return modules, nil
+}
+
+func detectLicense(dir string) license {
+	if dir == "" {
+		return license{}
+	}
+	for _, name := range licenseNames {
+		path := filepath.Join(dir, name)
+		content, err := os.ReadFile(path)
+		if err != nil || len(content) == 0 {
+			continue
+		}
+		text := string(content)
+		if len(text) > 32*1024 {
+			text = text[:32*1024]
+		}
+		return license{SPDXID: matchSPDX(text), Text: text, Found: true}
+	}
+	// Some small modules declare their license only in the README.
+	for _, name := range []string{"README.md", "README", "readme.md"} {
+		content, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil || len(content) == 0 {
+			continue
+		}
+		text := string(content)
+		if spdx := matchSPDX(text); spdx != "LicenseRef-unknown" {
+			return license{SPDXID: spdx, Text: text, Found: true}
+		}
+	}
+	return license{}
+}
+
+// matchSPDX returns a best-effort SPDX id for a license text. It is a heuristic:
+// the full NOTICE ships every detected license text for human review.
+func matchSPDX(text string) string {
+	for _, known := range knownLicenses {
+		if strings.Contains(text, known.Needle) {
+			return known.SPDX
+		}
+	}
+	return "LicenseRef-unknown"
+}
+
+// buildSBOM emits a CycloneDX 1.4 document whose serial number is derived from
+// the sorted component list, so identical module graphs yield identical bytes.
+func buildSBOM(modules []module, appVersion string) ([]byte, error) {
+	modules = sortedModules(modules)
+	components := make([]map[string]any, 0, len(modules))
+	for _, module := range modules {
+		purl := "pkg:golang/" + module.Path + "@" + module.Version
+		component := map[string]any{
+			"type":    "library",
+			"bom-ref": purl,
+			"name":    module.Path,
+			"version": module.Version,
+			"purl":    purl,
+		}
+		if lic := detectLicense(module.Dir); lic.Found {
+			component["licenses"] = []map[string]any{{
+				"license": map[string]any{"id": lic.SPDXID},
+			}}
+		}
+		components = append(components, component)
+	}
+	serialHash := sha256.New()
+	for _, module := range modules {
+		serialHash.Write([]byte(module.Path + "@" + module.Version + "\n"))
+	}
+	serialHex := hex.EncodeToString(serialHash.Sum(nil)[:16])
+	serial := "urn:uuid:" + serialHex[0:8] + "-" + serialHex[8:12] + "-" +
+		serialHex[12:16] + "-" + serialHex[16:20] + "-" + serialHex[20:32]
+
+	document := map[string]any{
+		"bomFormat":    "CycloneDX",
+		"specVersion":  "1.4",
+		"serialNumber": serial,
+		"version":      1,
+		"metadata": map[string]any{
+			"component": map[string]any{
+				"type":    "application",
+				"bom-ref": "pkg:golang/cyberagent-workbench@" + appVersion,
+				"name":    "cyberagent-workbench",
+				"version": appVersion,
+			},
+		},
+		"components": components,
+	}
+	return json.MarshalIndent(document, "", "  ")
+}
+
+func sortedModules(modules []module) []module {
+	copyModules := append([]module(nil), modules...)
+	sort.Slice(copyModules, func(i, j int) bool { return copyModules[i].Path < copyModules[j].Path })
+	return copyModules
+}
+
+func buildNotice(modules []module) []byte {
+	modules = sortedModules(modules)
+	var builder strings.Builder
+	builder.WriteString("Prayu Desktop — Third-Party Notices\n\n")
+	builder.WriteString("The Desktop build includes the following third-party Go modules.\n")
+	builder.WriteString("Licenses were detected from each module's LICENSE file; full texts follow.\n\n")
+	for _, module := range modules {
+		lic := detectLicense(module.Dir)
+		spdx := "unknown"
+		if lic.Found {
+			spdx = lic.SPDXID
+		}
+		fmt.Fprintf(&builder, "- %s@%s (%s)\n", module.Path, module.Version, spdx)
+	}
+	builder.WriteString("\n--- Full license texts ---\n\n")
+	for _, module := range modules {
+		lic := detectLicense(module.Dir)
+		if !lic.Found {
+			continue
+		}
+		fmt.Fprintf(&builder, "== %s@%s ==\n%s\n\n", module.Path, module.Version, lic.Text)
+	}
+	return []byte(builder.String())
+}
+
+// createDeterministicZip writes a ZIP whose entries are sorted and all carry
+// the fixed 1980-01-01 timestamp, so the same input directory yields identical
+// ZIP bytes. It never records absolute paths or filesystem metadata.
+func createDeterministicZip(sourceDir, outputPath string) error {
+	var files []string
+	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		relative, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return err
+		}
+		if strings.ContainsRune(relative, '\\') {
+			return fmt.Errorf("unexpected backslash in ZIP entry %q", relative)
+		}
+		files = append(files, relative)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	sort.Strings(files)
+
+	output, err := os.Create(outputPath)
+	if err != nil {
+		return err
+	}
+	defer output.Close()
+	writer := zip.NewWriter(output)
+	for _, name := range files {
+		entry, err := writer.CreateHeader(&zip.FileHeader{
+			Name:     name,
+			Method:   zip.Deflate,
+			Modified: zipTimestamp,
+		})
+		if err != nil {
+			return err
+		}
+		source, err := os.Open(filepath.Join(sourceDir, name))
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(entry, source)
+		source.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+	}
+	return writer.Close()
+}

--- a/cmd/releasegen/main_test.go
+++ b/cmd/releasegen/main_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDetectLicense(t *testing.T) {
+	mitDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(mitDir, "LICENSE"),
+		[]byte("MIT License\n\nPermission is hereby granted, free of charge"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if lic := detectLicense(mitDir); !lic.Found || lic.SPDXID != "MIT" {
+		t.Fatalf("MIT license = %#v", lic)
+	}
+
+	apacheDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(apacheDir, "LICENSE.txt"),
+		[]byte("Apache License\nVersion 2.0"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if lic := detectLicense(apacheDir); !lic.Found || lic.SPDXID != "Apache-2.0" {
+		t.Fatalf("Apache license = %#v", lic)
+	}
+
+	if lic := detectLicense(t.TempDir()); lic.Found {
+		t.Fatalf("absent license unexpectedly found: %#v", lic)
+	}
+}
+
+func TestBuildSBOMIsDeterministicCycloneDX(t *testing.T) {
+	modules := []module{
+		{Path: "github.com/example/b", Version: "v1.0.0", Dir: t.TempDir()},
+		{Path: "github.com/example/a", Version: "v2.0.0", Dir: t.TempDir()},
+	}
+	first, err := buildSBOM(modules, "v0.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := buildSBOM(modules, "v0.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Fatal("SBOM is not deterministic")
+	}
+	var document struct {
+		BomFormat   string `json:"bomFormat"`
+		SpecVersion string `json:"specVersion"`
+		Components  []struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+			Purl    string `json:"purl"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal(first, &document); err != nil {
+		t.Fatal(err)
+	}
+	if document.BomFormat != "CycloneDX" || document.SpecVersion != "1.4" {
+		t.Fatalf("SBOM metadata = %#v", document)
+	}
+	if len(document.Components) != 2 ||
+		document.Components[0].Name != "github.com/example/a" ||
+		document.Components[1].Name != "github.com/example/b" {
+		t.Fatalf("SBOM components not sorted: %#v", document.Components)
+	}
+}
+
+func TestBuildNoticeListsModulesAndLicenseText(t *testing.T) {
+	mitDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(mitDir, "LICENSE"),
+		[]byte("MIT License"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	modules := []module{{Path: "github.com/example/mit", Version: "v1.0.0", Dir: mitDir}}
+	notice := buildNotice(modules)
+	if !strings.Contains(string(notice), "github.com/example/mit@v1.0.0 (MIT)") ||
+		!strings.Contains(string(notice), "MIT License") {
+		t.Fatalf("NOTICE is incomplete: %s", notice)
+	}
+}
+
+func TestCreateDeterministicZipIsByteStable(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "b.txt"), []byte("beta"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "a.txt"), []byte("alpha"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	first := filepath.Join(t.TempDir(), "first.zip")
+	second := filepath.Join(t.TempDir(), "second.zip")
+	if err := createDeterministicZip(source, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := createDeterministicZip(source, second); err != nil {
+		t.Fatal(err)
+	}
+	firstBytes, err := os.ReadFile(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondBytes, err := os.ReadFile(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(firstBytes) != string(secondBytes) {
+		t.Fatal("deterministic ZIP differs across runs")
+	}
+}

--- a/scripts/package-portable-zip.ps1
+++ b/scripts/package-portable-zip.ps1
@@ -1,0 +1,106 @@
+[CmdletBinding()]
+param(
+    [string]$OutputDirectory = "build/desktop",
+    [string]$Version = "v0.1.0"
+)
+
+<#
+.SYNOPSIS
+Packages the Desktop portable ZIP with SBOM, NOTICE, LICENSE, README, checksums,
+and a build manifest (issue #56).
+
+.DESCRIPTION
+Collects the built EXE, operator-preview launcher, local test guide, LICENSE,
+README, NOTICE, CycloneDX SBOM, and release metadata into a single portable ZIP,
+then emits a SHA256SUMS file and a build manifest. No secret, user data, cache,
+debug log, source map, or untracked directory is included. The ZIP container
+timestamps are documented as non-reproducible; the EXE and every contained file
+hash are reproducible under a fixed toolchain and SOURCE_DATE_EPOCH.
+#>
+
+$ErrorActionPreference = "Stop"
+$repositoryRoot = [System.IO.Path]::GetFullPath((Split-Path -Parent $PSScriptRoot))
+$outputRoot = [System.IO.Path]::GetFullPath((Join-Path $repositoryRoot $OutputDirectory))
+$binaryPath = Join-Path $outputRoot "cyberagent-desktop.exe"
+$metadataPath = Join-Path $outputRoot "release-metadata.json"
+$launcherPath = Join-Path $outputRoot "Start-Prayu-Operator-Preview.cmd"
+$guidePath = Join-Path $outputRoot "LOCAL-TEST-GUIDE.txt"
+$licensePath = Join-Path $repositoryRoot "LICENSE"
+$readmePath = Join-Path $repositoryRoot "README.md"
+$zipName = "Prayu-portable-$Version-windows-amd64.zip"
+$zipPath = Join-Path $outputRoot $zipName
+
+foreach ($required in @($binaryPath, $metadataPath, $launcherPath, $guidePath, $licensePath, $readmePath)) {
+    if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
+        throw "Portable ZIP input is missing: $required"
+    }
+}
+
+# SBOM + NOTICE
+& go run ./cmd/releasegen -out $outputRoot -version $Version
+if ($LASTEXITCODE -ne 0) { throw "releasegen failed" }
+$sbomPath = Join-Path $outputRoot "sbom.json"
+$noticePath = Join-Path $outputRoot "NOTICE"
+
+# Staging directory (inside build output, never containing user data)
+$staging = Join-Path $outputRoot (".portable-staging-" + [guid]::NewGuid().ToString("N"))
+[System.IO.Directory]::CreateDirectory($staging) | Out-Null
+try {
+    Copy-Item -LiteralPath $binaryPath -Destination (Join-Path $staging "cyberagent-desktop.exe")
+    Copy-Item -LiteralPath $launcherPath -Destination (Join-Path $staging (Split-Path -Leaf $launcherPath))
+    Copy-Item -LiteralPath $guidePath -Destination (Join-Path $staging (Split-Path -Leaf $guidePath))
+    Copy-Item -LiteralPath $licensePath -Destination (Join-Path $staging "LICENSE")
+    Copy-Item -LiteralPath $readmePath -Destination (Join-Path $staging "README.md")
+    Copy-Item -LiteralPath $noticePath -Destination (Join-Path $staging "NOTICE")
+    Copy-Item -LiteralPath $sbomPath -Destination (Join-Path $staging "sbom.json")
+    Copy-Item -LiteralPath $metadataPath -Destination (Join-Path $staging "release-metadata.json")
+
+    if (Test-Path -LiteralPath $zipPath -PathType Leaf) {
+        Remove-Item -LiteralPath $zipPath -Force
+    }
+    & go run ./cmd/releasegen -zip $staging -out $outputRoot -zip-name $zipName
+    if ($LASTEXITCODE -ne 0) { throw "deterministic ZIP packaging failed" }
+
+    $zipHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $zipPath).Hash.ToLowerInvariant()
+    $binaryHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $binaryPath).Hash.ToLowerInvariant()
+    $sbomHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $sbomPath).Hash.ToLowerInvariant()
+    $noticeHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $noticePath).Hash.ToLowerInvariant()
+
+    $sumsPath = Join-Path $outputRoot "SHA256SUMS"
+    $sums = @(
+        "$binaryHash  cyberagent-desktop.exe",
+        "$zipHash  $zipName",
+        "$sbomHash  sbom.json",
+        "$noticeHash  NOTICE"
+    ) -join "`n"
+    [System.IO.File]::WriteAllText($sumsPath, $sums + "`n", [System.Text.UTF8Encoding]::new($false))
+
+    $manifest = [ordered]@{
+        protocol_version = "portable_zip_manifest.v1"
+        zip_name = $zipName
+        zip_sha256 = $zipHash
+        binary_sha256 = $binaryHash
+        sbom_sha256 = $sbomHash
+        notice_sha256 = $noticeHash
+        version = $Version
+        zip_timestamps_reproducible = $true
+        contents = @(
+            "cyberagent-desktop.exe", "Start-Prayu-Operator-Preview.cmd",
+            "LOCAL-TEST-GUIDE.txt", "LICENSE", "README.md", "NOTICE",
+            "sbom.json", "release-metadata.json"
+        )
+    }
+    $manifestPath = Join-Path $outputRoot "portable-zip-manifest.json"
+    [System.IO.File]::WriteAllText($manifestPath, (($manifest | ConvertTo-Json -Depth 4) + "`n"),
+        [System.Text.UTF8Encoding]::new($false))
+
+    Write-Output "portable_zip: $zipPath"
+    Write-Output "portable_zip_sha256: $zipHash"
+    Write-Output "sha256sums: $sumsPath"
+    Write-Output "manifest: $manifestPath"
+}
+finally {
+    if (Test-Path -LiteralPath $staging) {
+        Remove-Item -LiteralPath $staging -Recurse -Force
+    }
+}


### PR DESCRIPTION
## 背景

issue #56（父任务 #37）：当前 `cyberagent-desktop.exe` 是开发者预览产物，缺少正式 portable ZIP 的可复现构建、依赖/SBOM、许可证清单、版本元数据和校验和。ADR 0034 要求任何可分发 ZIP 必须携带第三方 notice、SBOM 和哈希。

## 本次改动

- **`cmd/releasegen`**：生成确定性的 CycloneDX 1.4 SBOM + 第三方 `NOTICE`，并提供一个固定时间戳（1980-01-01）的确定性 ZIP 打包。
  - SBOM 覆盖**实际编译进 desktop 二进制的模块**（`go list -deps -tags "desktop,production,wv2runtime.error"`），不是完整模块图，且序列号由模块图哈希派生（无随机 UUID/时间戳）。
  - 许可证识别 61/61 全覆盖（含 README 里声明 "License: MIT" 的小模块）。
  - 不调用 `go mod download`，因此不会改写 `go.sum`。
- **`scripts/package-portable-zip.ps1`**：把 EXE、launcher、guide、LICENSE、README、NOTICE、sbom.json、release-metadata.json 打包成便携 ZIP，并生成 `SHA256SUMS` 与 `portable-zip-manifest.json`。ZIP 用 `releasegen -zip` 固定时间戳，字节级可复现。
- **`.github/workflows/release-desktop.yml`**：release CI（tag / workflow_dispatch）——`go mod tidy -diff`（lockfile 漂移 fail-closed）→ 构建（含复现校验）→ 打包 → 上传 artifact。
- **README**：双语「便携 ZIP 下载与验证」章节 + SmartScreen 预期说明。

## 测试覆盖

- `cmd/releasegen`：license 检测（MIT/Apache/缺失）、SBOM 确定性 + 排序、NOTICE 完整性、确定性 ZIP 字节稳定。
- 本机验证：`go build`/`go vet`/`go test ./cmd/releasegen` 通过；打包全流程两次运行 ZIP SHA-256 一致；`go.sum`/`go.mod` 无漂移。

## 验证结果

- `go build ./...`、`go vet ./...`、`go test ./cmd/releasegen` 通过。
- 便携 ZIP（61 个模块 SBOM，许可证 61/61 识别）生成成功，两次打包 SHA-256 字节级一致（`zip_timestamps_reproducible: true`）。

## 安全边界与非目标

- ZIP 只含 8 个白名单文件，无 secret/用户数据/缓存/调试日志/源映射。
- SBOM/NOTICE 确定性、无绝对个人路径、无随机标识。
- 不打包 MSIX 安装/升级（#57）；不执行真正的 `gh release create` 上传（需 tag + 人工发布动作）；许可证识别是启发式，`NOTICE` 附全文供人工复核。
- CI workflow 尚未在 GitHub Actions 的 `windows-latest` 上实跑（本机已逐 step 复现）。

Refs #56
