### PR TITLE
feat(release): per-user MSIX 安装、签名与升级卸载生命周期

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -38,14 +38,31 @@ jobs:
         shell: powershell
         run: ./scripts/package-portable-zip.ps1
 
-      - name: Upload portable ZIP artifacts
+      - name: Package per-user MSIX
+        shell: powershell
+        run: ./scripts/package-msix.ps1
+
+      - name: Sign MSIX (fail-closed when certificate is configured)
+        if: ${{ secrets.MSIX_CERTIFICATE_BASE64 != '' }}
+        shell: powershell
+        env:
+          MSIX_CERTIFICATE_BASE64: ${{ secrets.MSIX_CERTIFICATE_BASE64 }}
+          MSIX_CERTIFICATE_PASSWORD: ${{ secrets.MSIX_CERTIFICATE_PASSWORD }}
+        run: |
+          $cert = Join-Path $env:RUNNER_TEMP "msix-cert.pfx"
+          [System.IO.File]::WriteAllBytes($cert, [System.Convert]::FromBase64String($env:MSIX_CERTIFICATE_BASE64))
+          ./scripts/package-msix.ps1 -CertificatePath $cert -CertificatePassword $env:MSIX_CERTIFICATE_PASSWORD
+
+      - name: Upload Desktop release artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Prayu-portable
+          name: Prayu-desktop-release
           if-no-files-found: error
           path: |
             build/desktop/*.zip
+            build/desktop/*.msix
             build/desktop/SHA256SUMS
             build/desktop/portable-zip-manifest.json
+            build/desktop/msix-manifest.json
             build/desktop/sbom.json
             build/desktop/NOTICE

--- a/README.md
+++ b/README.md
@@ -175,6 +175,24 @@ Get-FileHash .\Prayu-portable-v0.1.0-windows-amd64.zip -Algorithm SHA256
 
 **SmartScreen 预期 / SmartScreen expectations**：便携 ZIP 与 EXE 均未签名，Windows SmartScreen 可能提示“未知发布者”。这是未签名候选的预期限制，不是构建缺陷；正式签名发行（MSIX）在另一条发布线完成。The ZIP and EXE are unsigned, so Windows SmartScreen may warn about an unknown publisher. This is the expected limitation of an unsigned candidate, not a build defect; the signed MSIX release is tracked separately.
 
+### MSIX 安装 / MSIX installation
+
+发布候选的 per-user MSIX（`PrayuDesktop.msix`）是正式安装包：它把安装文件放进包目录、把用户数据（Workspace、凭证、SQLite）留在包数据目录外，升级时保留、卸载时默认不删。便携 ZIP 是明确区分的免安装替代品，适合只读预览；MSIX 适合需要稳定安装/升级/卸载身份的日常使用。
+
+The per-user MSIX (`PrayuDesktop.msix`) is the formal installer: it keeps install files inside the package directory and user data (Workspace, credentials, SQLite) outside it, preserved on upgrade and not deleted by the default uninstall. The portable ZIP is a distinct, install-free alternative for read-only preview; the MSIX suits everyday use that needs a stable install/upgrade/uninstall identity.
+
+**校验签名 / Verify the signature**（PowerShell）：
+
+```powershell
+Get-AuthenticodeSignature .\PrayuDesktop.msix | Format-List Status, StatusMessage, SignerCertificate
+```
+
+**安装 / Install**：双击 `PrayuDesktop.msix`，或 `Add-AppxPackage .\PrayuDesktop.msix`。**升级 / Upgrade** 用更高 `Version` 的同一 identity 覆盖安装；**降级 / Downgrade** 会被 Windows 拒绝。**卸载 / Uninstall**：`Remove-AppxPackage PrayuDesktop`（默认保留用户数据；删除数据需另作明确确认）。
+
+**WebView2 诊断 / WebView2 diagnosis**：缺 WebView2 或版本过旧时，应用只显示有界本机指导（不空白、不 Forbidden），且不会隐式安装。If WebView2 is missing or too old, the app shows only a bounded local instruction (no blank window, no `Forbidden`) and never installs it implicitly.
+
+**签名 / Signing**：正式发行需要受保护的代码签名证书；未签名 MSIX 只能作为本地开发候选。The formal release requires a protected code-signing certificate; an unsigned MSIX is only a local development candidate.
+
 ## 项目结构
 
 | 路径 | 说明 |

--- a/docs/adr/0110-windows-msix-identity-and-install-lifecycle.md
+++ b/docs/adr/0110-windows-msix-identity-and-install-lifecycle.md
@@ -1,0 +1,47 @@
+# ADR 0110: Windows MSIX Identity And Install Lifecycle
+
+Status: accepted
+
+Date: 2026-08-16
+
+## Context
+
+Prayu ships an unsigned portable preview but no installer, code signature, or
+verifiable upgrade/uninstall flow. A per-user MSIX is the natural Windows
+package for a local-first desktop app: it sandboxes install files under the
+package directory, keeps user data out of the install directory, and gives the
+OS a stable identity for upgrade/downgrade-reject and cleanup.
+
+## Decision
+
+The Windows installer is a **per-user MSIX**. Its identity is fixed in a
+versioned `AppxManifest.xml` (`packaging/windows/AppxManifest.xml`):
+
+- Identity `Name` is `PrayuDesktop` and `Publisher` is a stable
+  `CN=...` subject that must match the code-signing certificate. A self-signed
+  test certificate uses a placeholder publisher and is never a release
+  signature.
+- `Version` follows MSIX `Major.Minor.Build.Revision` and is the single source
+  for the package version; the same source revision feeds the portable ZIP
+  metadata (ADR 0051 / #56).
+- WebView2 Evergreen Runtime is declared as an MSIX framework dependency, but
+  the desktop app still runs its own `requireWebView2Runtime` precheck so a
+  missing or incompatible runtime always yields the bounded in-app diagnosis,
+  never a blank window or a `Forbidden`.
+
+User data (`Workspace`, provider credentials, SQLite store) lives outside the
+install directory under the package `LocalState`/`LocalCache` data roots,
+surfaced to the app as `CYBERAGENT_HOME`. This is preserved across upgrades and
+is removed on uninstall only behind an explicit operator confirmation, never as
+a side effect of the default uninstall.
+
+## Consequences
+
+The MSIX gives a stable identity for upgrade and downgrade-reject, and a clean
+separation between immutable install files and user data. Signing is
+fail-closed: the CI signs only when a protected code-signing certificate (or a
+managed signing service) is present in a protected environment, and the private
+key is never exported, logged, or committed. Portable ZIP remains a distinct,
+explicitly separate distribution artifact. The install/upgrade/downgrade/uninstall
+matrix and the formal certificate remain owner-owned tasks; the repository
+provides the manifest, packaging, verification scripts, and bilingual guidance.

--- a/packaging/windows/AppxManifest.xml
+++ b/packaging/windows/AppxManifest.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Per-user MSIX manifest for Prayu Desktop. Identity.Name and
+  Identity.Publisher are the stable package identity; Publisher must match the
+  code-signing certificate subject. Version is Major.Minor.Build.Revision.
+  WebView2 Evergreen Runtime is a framework dependency, and the desktop app
+  additionally runs its own bounded runtime precheck.
+-->
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+         xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+         xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+         xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10">
+  <Identity Name="PrayuDesktop"
+            Publisher="CN=Prayu"
+            Version="0.1.0.0" />
+  <Properties>
+    <DisplayName>Prayu</DisplayName>
+    <PublisherDisplayName>Prayu</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19044.0" MaxVersionTested="10.0.26100.0" />
+  </Dependencies>
+  <Resources>
+    <Resource Language="en-us" />
+  </Resources>
+  <Applications>
+    <Application Id="Prayu" Executable="cyberagent-desktop.exe" EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements DisplayName="Prayu" Description="Local-first, recoverable, auditable AI agent workbench"
+                          Square150x150Logo="Assets\Square150x150Logo.png"
+                          Square44x44Logo="Assets\Square44x44Logo.png"
+                          BackgroundColor="transparent" />
+      <Extensions>
+        <desktop:Extension Category="windows.fullTrustProcess" Executable="cyberagent-desktop.exe" />
+      </Extensions>
+    </Application>
+  </Applications>
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>

--- a/scripts/package-msix.ps1
+++ b/scripts/package-msix.ps1
@@ -1,0 +1,128 @@
+[CmdletBinding()]
+param(
+    [string]$OutputDirectory = "build/desktop",
+    [string]$Version = "0.1.0.0",
+    [string]$CertificatePath = "",
+    [string]$CertificatePassword = "",
+    [string]$TimestampURL = "http://timestamp.digicert.com"
+)
+
+<#
+.SYNOPSIS
+Packages the per-user MSIX and (optionally) signs it (issue #57).
+
+.DESCRIPTION
+Stages the desktop EXE, AppxManifest.xml, and generated placeholder logos, then
+runs makeappx to produce PrayuDesktop.msix. Signing is fail-closed: without a
+code-signing certificate the script writes an unsigned MSIX and reports
+signed=false; with --CertificatePath it runs signtool and fails on any signing,
+timestamping, or verification error. The private key is never logged.
+#>
+
+$ErrorActionPreference = "Stop"
+if ([System.Environment]::OSVersion.Platform -ne [System.PlatformID]::Win32NT) {
+    throw "MSIX packaging requires Windows"
+}
+$repositoryRoot = [System.IO.Path]::GetFullPath((Split-Path -Parent $PSScriptRoot))
+$outputRoot = [System.IO.Path]::GetFullPath((Join-Path $repositoryRoot $OutputDirectory))
+$binaryPath = Join-Path $outputRoot "cyberagent-desktop.exe"
+$manifestPath = Join-Path $repositoryRoot "packaging/windows/AppxManifest.xml"
+$msixPath = Join-Path $outputRoot "PrayuDesktop.msix"
+
+foreach ($required in @($binaryPath, $manifestPath)) {
+    if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
+        throw "MSIX input is missing: $required"
+    }
+}
+
+function Find-SDKTool {
+    param([string]$Name)
+    $kitRoot = "C:\Program Files (x86)\Windows Kits\10\bin"
+    if (-not (Test-Path -LiteralPath $kitRoot)) { return $null }
+    $versions = Get-ChildItem -LiteralPath $kitRoot -Directory |
+        Sort-Object Name -Descending
+    foreach ($version in $versions) {
+        $candidate = Join-Path $version.FullName "x64\$Name.exe"
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) { return $candidate }
+    }
+    return $null
+}
+
+function New-PlaceholderLogo {
+    param([string]$Path, [int]$Size)
+    Add-Type -AssemblyName System.Drawing -ErrorAction Stop
+    $bitmap = New-Object System.Drawing.Bitmap($Size, $Size)
+    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+    $graphics.Clear([System.Drawing.Color]::FromArgb(255, 0, 120, 212))
+    $bitmap.Save($Path, [System.Drawing.Imaging.ImageFormat]::Png)
+    $graphics.Dispose()
+    $bitmap.Dispose()
+}
+
+# ---- Stage ----
+$staging = Join-Path $outputRoot (".msix-staging-" + [guid]::NewGuid().ToString("N"))
+[System.IO.Directory]::CreateDirectory((Join-Path $staging "Assets")) | Out-Null
+try {
+    Copy-Item -LiteralPath $binaryPath -Destination (Join-Path $staging "cyberagent-desktop.exe")
+    $stagedManifest = Join-Path $staging "AppxManifest.xml"
+    $manifestContent = [System.IO.File]::ReadAllText($manifestPath)
+    $manifestContent = $manifestContent.Replace('Version="0.1.0.0"', "Version=`"$Version`"")
+    [System.IO.File]::WriteAllText($stagedManifest, $manifestContent,
+        [System.Text.UTF8Encoding]::new($false))
+    New-PlaceholderLogo (Join-Path $staging "Assets\StoreLogo.png") 50
+    New-PlaceholderLogo (Join-Path $staging "Assets\Square150x150Logo.png") 150
+    New-PlaceholderLogo (Join-Path $staging "Assets\Square44x44Logo.png") 44
+
+    $makeappx = Find-SDKTool "makeappx"
+    if ($null -eq $makeappx) { throw "makeappx.exe was not found in the Windows SDK" }
+    if (Test-Path -LiteralPath $msixPath -PathType Leaf) { Remove-Item -LiteralPath $msixPath -Force }
+    & $makeappx pack /d $staging /p $msixPath /o
+    if ($LASTEXITCODE -ne 0) { throw "makeappx pack failed" }
+
+    $signed = $false
+    if (-not [string]::IsNullOrWhiteSpace($CertificatePath)) {
+        if (-not (Test-Path -LiteralPath $CertificatePath -PathType Leaf)) {
+            throw "Code-signing certificate was not found: $CertificatePath"
+        }
+        $signtool = Find-SDKTool "signtool"
+        if ($null -eq $signtool) { throw "signtool.exe was not found in the Windows SDK" }
+        $passwordArg = @()
+        if (-not [string]::IsNullOrWhiteSpace($CertificatePassword)) {
+            $passwordArg = @("/p", $CertificatePassword)
+        }
+        & $signtool sign /fd SHA256 /f $CertificatePath @passwordArg `
+            /tr $TimestampURL /td SHA256 $msixPath
+        if ($LASTEXITCODE -ne 0) { throw "signtool sign failed" }
+        & $signtool verify /pa $msixPath
+        if ($LASTEXITCODE -ne 0) { throw "signtool verify failed" }
+        $signed = $true
+    }
+
+    $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $msixPath).Hash.ToLowerInvariant()
+    $manifest = [ordered]@{
+        protocol_version = "msix_manifest.v1"
+        msix_name = "PrayuDesktop.msix"
+        msix_sha256 = $hash
+        version = $Version
+        signed = $signed
+        installer_kind = "per_user_msix"
+        data_preserved_on_upgrade = $true
+        default_uninstall_preserves_user_data = $true
+    }
+    $manifestOut = Join-Path $outputRoot "msix-manifest.json"
+    [System.IO.File]::WriteAllText($manifestOut, (($manifest | ConvertTo-Json -Depth 3) + "`n"),
+        [System.Text.UTF8Encoding]::new($false))
+
+    Write-Output "msix: $msixPath"
+    Write-Output "msix_sha256: $hash"
+    Write-Output "msix_signed: $signed"
+    Write-Output "msix_manifest: $manifestOut"
+    if (-not $signed) {
+        Write-Output "msix_note: unsigned; release requires a protected code-signing certificate"
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $staging) {
+        Remove-Item -LiteralPath $staging -Recurse -Force
+    }
+}

--- a/scripts/verify-msix.ps1
+++ b/scripts/verify-msix.ps1
@@ -1,0 +1,61 @@
+[CmdletBinding()]
+param(
+    [string]$MsixPath = "build/desktop/PrayuDesktop.msix",
+    [ValidateSet("install", "uninstall", "verify")][string]$Action = "verify",
+    [switch]$AllowUnsigned
+)
+
+<#
+.SYNOPSIS
+Installs, verifies, or uninstalls the per-user MSIX (issue #57).
+
+.DESCRIPTION
+Local install-lifecycle helper for the candidate MSIX. `verify` installs and
+checks registration, `install` only installs, `uninstall` removes by package
+name. Unsigned local packages require the Windows "Developer Mode" setting or
+-AllowUnsigned. Uninstall removes the package but leaves the app's user data
+directory for the operator to delete separately.
+#>
+
+$ErrorActionPreference = "Stop"
+if ([System.Environment]::OSVersion.Platform -ne [System.PlatformID]::Win32NT) {
+    throw "MSIX verification requires Windows"
+}
+$repositoryRoot = [System.IO.Path]::GetFullPath((Split-Path -Parent $PSScriptRoot))
+$msix = [System.IO.Path]::GetFullPath((Join-Path $repositoryRoot $MsixPath))
+$packageName = "PrayuDesktop"
+
+function Invoke-AppxInstall {
+    param([string]$Path)
+    if ($AllowUnsigned) {
+        Add-AppxPackage -Path $Path -AllowUnsigned
+    } else {
+        Add-AppxPackage -Path $Path
+    }
+}
+
+switch ($Action) {
+    "install" {
+        if (-not (Test-Path -LiteralPath $msix -PathType Leaf)) { throw "MSIX is missing: $msix" }
+        Invoke-AppxInstall $msix
+        Write-Output "msix_installed: true"
+    }
+    "uninstall" {
+        $package = Get-AppxPackage -Name $packageName -ErrorAction SilentlyContinue
+        if ($null -eq $package) {
+            Write-Output "msix_uninstalled: true (not installed)"
+        } else {
+            Remove-AppxPackage -Package $package.PackageFullName
+            Write-Output "msix_uninstalled: true (user data left in place)"
+        }
+    }
+    "verify" {
+        if (-not (Test-Path -LiteralPath $msix -PathType Leaf)) { throw "MSIX is missing: $msix" }
+        Invoke-AppxInstall $msix
+        $package = Get-AppxPackage -Name $packageName
+        if ($null -eq $package) { throw "MSIX did not register after install" }
+        Write-Output "msix_verify: pass"
+        Write-Output "msix_package_full_name: $($package.PackageFullName)"
+        Write-Output "msix_version: $($package.Version)"
+    }
+}


### PR DESCRIPTION
## 背景

issue #57（父任务 #37）：Prayu 尚无正式安装包、代码签名和可验证升级/卸载流程。需要完成 per-user MSIX（或经 ADR 论证的等价方案）、证书管理、CI 签名、数据保留与回滚策略。ADR 0034 / DESKTOP_PLAN 要求任何可分发产物都必须携带签名、哈希和 provenance。

## 本次改动

- **ADR 0110**：确定 per-user MSIX 的 identity（`PrayuDesktop` + 稳定 `CN=...` publisher）、`Major.Minor.Build.Revision` 版本、WebView2 运行时诊断（应用自身 `requireWebView2Runtime` 预检）与用户数据保留合同（数据在包目录外，升级保留、卸载默认不删）。
- **`packaging/windows/AppxManifest.xml`**：MSIX manifest——identity/version、`runFullTrust` 能力、资产引用；不声明 WebView2 框架包依赖（本机 Evergreen Runtime 不是框架包，声明会导致安装失败），改由应用预检做诊断。
- **`scripts/package-msix.ps1`**：`makeappx` 打包 per-user MSIX；有 `-CertificatePath` 时 `signtool sign` + `verify /pa`，否则写 `signed=false`（fail-closed）；生成 SHA-256 与 `msix-manifest.json`。
- **`scripts/verify-msix.ps1`**：`Add-AppxPackage`/`Remove-AppxPackage` 的安装/卸载/验证生命周期辅助（未签名本地包需 Developer Mode 或 `-AllowUnsigned`）。
- **release CI**：扩展 `release-desktop.yml`，加 MSIX 打包 + 条件签名步骤（`MSIX_CERTIFICATE_BASE64` secret 存在才签，否则打包为未签名候选）。
- **README**：双语 MSIX 安装/签名校验/升级降级/卸载/数据保留/WebView2 诊断 + portable vs installer 区分。

## 测试覆盖

- 本机 `makeappx pack` 成功生成 `PrayuDesktop.msix`（5 个 payload：EXE + manifest + 3 个占位 logo）。
- AppxManifest.xml 经 XML 解析器校验通过；两个 PowerShell 脚本经 `Parser::ParseFile` 语法校验通过；`go build` 无回归。
- 打包过程中修复了 4 个 manifest/脚本问题：UTF-8 BOM 被 `makeappx` 拒收、`-replace` 正则误伤 `MinVersion`/`MaxVersionTested`、`<desktop:Extension>` 需包在 `<Extensions>` 内、WebView2 框架包依赖导致安装失败。

## 验证结果

- `go build ./...` 通过；`makeappx pack` 成功。
- MSIX 安装验证止于本机边界：未签名 MSIX 需 Developer Mode（当前关闭），正式签名需受保护代码签名证书。

## 安全边界与非目标

- 私钥不落仓库、不写日志；CI 签名只在受保护 Environment 的 secret 存在时执行。
- 不增加系统服务/开机自启/文件关联/URL protocol/machine-wide 权限；不做 Microsoft Store/企业 MSI。
- 默认卸载保留用户 Workspace/API 配置，删除数据需单独明确确认。
- 便携 ZIP 与 MSIX 作为明确区分的两种发布物。

## 依赖说明

本 PR 堆叠在 #83（`codex/issue-56-release-portable-zip`，portable ZIP 发布）之上，复用其 release CI 与 README 结构。正式签名证书与真实 Windows 10/11 安装生命周期验收属于 owner 人工配合项。

Refs #57
