### PR TITLE
fix(repository): authenticate remote branch probe

### DIFF
--- a/internal/repository/remote.go
+++ b/internal/repository/remote.go
@@ -204,7 +204,7 @@ func (e *RemoteExecutor) ExecuteGit(ctx context.Context, root string, spec Remot
 		args = []string{"pull", "--quiet", "--ff-only", spec.RemoteURL, spec.Branch}
 	case RemotePushBranch:
 		// New branch only: refuse to touch a branch that already exists.
-		exists, err := e.remoteBranchExists(ctx, root, spec)
+		exists, err := e.remoteBranchExists(ctx, root, spec, askpass, secret)
 		if err != nil {
 			return RemoteReceipt{}, err
 		}
@@ -214,12 +214,7 @@ func (e *RemoteExecutor) ExecuteGit(ctx context.Context, root string, spec Remot
 		}
 		args = []string{"push", "--quiet", spec.RemoteURL, "HEAD:refs/heads/" + spec.Branch}
 	}
-	command := exec.CommandContext(ctx, e.gitPath, append([]string{"-C", root, "--no-optional-locks",
-		"-c", "core.autocrlf=false", "-c", "http.proxy=", "-c", "https.proxy=",
-		"-c", "core.sshCommand=", "-c", "protocol.ext.allow=never"}, args...)...)
-	command.Dir = root
-	command.Env = append(hardenedGitEnvironment(),
-		"GIT_ASKPASS="+askpass, "GIT_PASSWORD="+secret)
+	command := e.remoteGitCommand(ctx, root, askpass, secret, args...)
 	var stdout, stderr boundedBuffer
 	command.Stdout = &stdout
 	command.Stderr = &stderr
@@ -253,9 +248,11 @@ func (e *RemoteExecutor) ExecuteGit(ctx context.Context, root string, spec Remot
 	return receipt, nil
 }
 
-func (e *RemoteExecutor) remoteBranchExists(ctx context.Context, root string, spec RemoteSpec) (bool, error) {
-	command := exec.CommandContext(ctx, e.gitPath, "-C", root, "ls-remote", "--heads", spec.RemoteURL, "refs/heads/"+spec.Branch)
-	command.Env = hardenedGitEnvironment()
+func (e *RemoteExecutor) remoteBranchExists(ctx context.Context, root string, spec RemoteSpec,
+	askpass, secret string,
+) (bool, error) {
+	command := e.remoteGitCommand(ctx, root, askpass, secret,
+		"ls-remote", "--heads", spec.RemoteURL, "refs/heads/"+spec.Branch)
 	var stdout, stderr boundedBuffer
 	command.Stdout = &stdout
 	command.Stderr = &stderr
@@ -264,6 +261,19 @@ func (e *RemoteExecutor) remoteBranchExists(ctx context.Context, root string, sp
 		return false, apperror.New(apperror.CodeFailedPrecondition, "remote branch probe failed")
 	}
 	return strings.TrimSpace(stdout.String()) != "", nil
+}
+
+func (e *RemoteExecutor) remoteGitCommand(ctx context.Context, root, askpass, secret string,
+	args ...string,
+) *exec.Cmd {
+	hardenedArgs := append([]string{"-C", root, "--no-optional-locks",
+		"-c", "core.autocrlf=false", "-c", "http.proxy=", "-c", "https.proxy=",
+		"-c", "core.sshCommand=", "-c", "protocol.ext.allow=never"}, args...)
+	command := exec.CommandContext(ctx, e.gitPath, hardenedArgs...)
+	command.Dir = root
+	command.Env = append(hardenedGitEnvironment(),
+		"GIT_ASKPASS="+askpass, "GIT_PASSWORD="+secret)
+	return command
 }
 
 func (e *RemoteExecutor) currentHead(ctx context.Context, root string) (string, error) {

--- a/internal/repository/remote_test.go
+++ b/internal/repository/remote_test.go
@@ -2,10 +2,13 @@ package repository
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -178,6 +181,73 @@ func TestRemoteAskpassHelperResolvesCredentialByName(t *testing.T) {
 		t.Fatalf("askpass helper: path=%q secret=%q err=%v", path, secret, err)
 	}
 	_ = os.Remove(path)
+}
+
+func TestRemoteGitCommandIsCredentialedAndHardened(t *testing.T) {
+	executor := newRemoteExecutor(t)
+	command := executor.remoteGitCommand(t.Context(), t.TempDir(),
+		"C:/temporary/askpass.cmd", "secret-token-value",
+		"ls-remote", "--heads", "https://example.com/repo.git", "refs/heads/feature")
+	args := strings.Join(command.Args, "\x00")
+	for _, required := range []string{
+		"--no-optional-locks", "http.proxy=", "https.proxy=",
+		"core.sshCommand=", "protocol.ext.allow=never", "ls-remote",
+	} {
+		if !strings.Contains(args, required) {
+			t.Fatalf("remote branch probe omitted hardened argument %q: %q", required, command.Args)
+		}
+	}
+	if strings.Contains(args, "secret-token-value") {
+		t.Fatalf("credential leaked into git argv: %q", command.Args)
+	}
+	environment := strings.Join(command.Env, "\x00")
+	for _, required := range []string{
+		"GIT_ASKPASS=C:/temporary/askpass.cmd", "GIT_PASSWORD=secret-token-value",
+	} {
+		if !strings.Contains(environment, required) {
+			t.Fatalf("remote branch probe omitted credential environment %q", required)
+		}
+	}
+}
+
+func TestRemoteBranchProbeAuthenticatesWithReferencedCredential(t *testing.T) {
+	credentials := credential.NewMemoryStore()
+	if err := credentials.Put(t.Context(), "private-remote", "secret-token-value"); err != nil {
+		t.Fatal(err)
+	}
+	executor, err := NewRemoteExecutor(credentials)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var authenticated atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		username, password, ok := request.BasicAuth()
+		if !ok {
+			w.Header().Set("WWW-Authenticate", `Basic realm="private Git"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if username != "secret-token-value" || password != "secret-token-value" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		authenticated.Store(true)
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+		_, _ = w.Write([]byte("001e# service=git-upload-pack\n00000000"))
+	}))
+	defer server.Close()
+	askpass, secret, err := executor.askpassHelper(t.Context(), "private-remote")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(askpass)
+	exists, err := executor.remoteBranchExists(t.Context(), t.TempDir(), RemoteSpec{
+		RemoteURL: server.URL + "/repository.git", Branch: "feature",
+	}, askpass, secret)
+	if err != nil || exists || !authenticated.Load() {
+		t.Fatalf("credentialed branch probe failed: exists=%t authenticated=%t err=%v",
+			exists, authenticated.Load(), err)
+	}
 }
 
 var _ = time.Now


### PR DESCRIPTION
## Summary
- pass the resolved askpass helper and credential secret into the pre-push `ls-remote` branch probe
- make branch probing and the subsequent push share one hardened Git command builder
- verify a private HTTP Git advertisement actually challenges and authenticates through askpass without putting the secret in argv

## Root cause
The push path resolved the named credential, but `remoteBranchExists` discarded it and used a separate, less-hardened environment. Private HTTPS repositories therefore failed during the new-branch safety probe before the credentialed push could run.

## Safety
- the secret remains child-process environment only and is absent from argv, receipts, and stored requests
- proxy, SSH wrapper, optional-lock, and external-protocol kill switches now apply identically to probe and push
- existing refusal to overwrite a remote branch is unchanged

## Verification
- `go test -count=1 ./internal/repository ./internal/application ./internal/app`
- authenticated private-remote branch-probe fixture
- `go vet ./internal/repository`
- `git diff --check`