### PR TITLE
fix(store): upgrade exact legacy v136 desktop profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ Partner Center 的 identity、版本、上传与 `runFullTrust` 认证步骤见
 完整逐切片原始记录保留在 [`PROGRESS_BOOK.md`](docs/PROGRESS_BOOK.md)，当前检查点与验收证据保留在 [`PROJECT_STATUS.md`](docs/PROJECT_STATUS.md)，恢复上下文见 [`PROJECT_MEMORY.md`](docs/PROJECT_MEMORY.md)。这些账本是历史记录，不应被当作待重新执行的任务列表。
 
 <details>
-<summary><strong>SQLite Schema v1-v136 迁移审计表 / Migration ledger</strong></summary>
+<summary><strong>SQLite Schema v1-v138 迁移审计表 / Migration ledger</strong></summary>
 
 此表是 Store 防漏迁移测试使用的审计合同。新增 schema 时必须按顺序追加，不得改写或删除既有行。
 
@@ -587,6 +587,7 @@ Partner Center 的 identity、版本、上传与 `runFullTrust` 认证步骤见
 | v135 | 持久化 Standard Code root Supervisor 的有界 Inspect→Edit→Execute→Verify 状态、预算、拒绝和结构化证据，并补全 Code Intel 调用账本约束 | persist bounded Inspect→Edit→Execute→Verify state, budgets, denials, and structural evidence for the Standard Code root Supervisor and complete the Code Intel call-ledger constraints |
 | v136 | 增加精确高风险提案、有界 Run grant 消费、持久等待/恢复、write-ahead 不确定性与漂移失效账本 | add exact risk proposals, bounded Run-grant consumption, durable wait/resume, write-ahead uncertainty, and drift invalidation ledgers |
 | v137 | 增加 Standard Code 最终 Checkpoint、Diff/Command Artifact 对齐、不可变完成收据与动态 stale 投影 | add the Standard Code final Checkpoint, aligned Diff/Command Artifacts, immutable completion receipts, and dynamic stale projection |
+| v138 | 精确兼容 v136 Windows 中间预览历史，并重建缺失的 Supervisor 高风险提案权限触发器 | accept the exact intermediate Windows preview v136 history and rebuild its missing Supervisor risk-authority triggers |
 
 </details>
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,12 +1,22 @@
 # Project Status
 
-Last updated: 2026-08-26
+Last updated: 2026-08-28
 
 > **Scope authority:** active mainline work targets the general-purpose Agent Harness and Code workflow. CTF-specific solving and offensive automation are optional add-ons and have no active implementation schedule. Historical references and percentages below remain audit history, not queued work. See [Product Scope](PRODUCT_SCOPE.md).
 
 ## Resume Context
 
-当前检查点是 issue #139 / SQLite schema v137。`standard_code_delivery.v1` 将最终
+当前数据库检查点是 SQLite schema v138。一个正式 v136 固化前的 Windows Desktop
+预览版写入了精确 checksum
+`5cccad921f47d44ac37f2206e91b355d55ce221d6c9c61e25e7fc08f1cbb6dbd`；其余 v136
+结构与正式定义一致，但缺少 `trg_risk_escalation_supervisor_authority_insert` 和
+`trg_host_command_supervisor_envelope_immutable`。迁移校验只为 version 136、正式 migration
+名称和这一个 checksum 开放窄兼容路径；任意其他 checksum、错误名称、版本断层或未知历史仍
+失败关闭。v138 在同一事务内重建两枚正式 trigger，不改写既有 v136 ledger，不删除、重置或
+替换业务数据。受影响数据库可原地前向升级，正式 v136/v137 数据库也收敛到同一最终定义；
+决策与回滚边界见 ADR 0146。
+
+上一功能检查点是 issue #139 / SQLite schema v137。`standard_code_delivery.v1` 将最终
 Checkpoint、base/head、真实 committed/index/worktree/untracked/conflict Diff、Command Runtime
 终态/exit/tree-reaped、输出摘要与 Artifact、重试次数、permission/backend generation 及未覆盖项
 收敛为同一不可变 receipt。只有全部验证对应当前 Drydock Workspace revision 且证据完整时才为

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ This directory separates user-facing documentation, current engineering state, a
 | [ADR 0141 / Durable-operation Identity Pilot](adr/0141-minimal-durable-operation-identity.md) | 无存储共享身份值对象、长度分隔摘要、Run creation / Scheduled Job 回放试点与领域 authority 边界 |
 | [ADR 0144 / Standard Code Release Gate](adr/0144-standard-code-release-gate-aggregation.md) | 同候选 packaged/product/security 证据聚合、Draft Release 传递、确定性复核与 Beta-only 发布边界 |
 | [ADR 0145 / Windows Two-Deliverable Release](adr/0145-windows-two-deliverable-release-contract.md) | Microsoft Store 包、可直接双击 EXE、内部 ZIP/sidecar 与启动器的发布边界 |
+| [ADR 0146 / Legacy v136 Compatibility](adr/0146-legacy-v136-supervisor-trigger-compatibility.md) | 精确旧 checksum 白名单、v138 Supervisor trigger 前向修复、原 ledger/业务数据保留与失败关闭边界 |
 | [Microsoft Store submission runbook](../packaging/windows/STORE-SUBMISSION.md) | Partner Center identity、Store version、`runFullTrust` 说明、上传与完成证据 |
 | [ADR 索引](adr/) | 权限、持久化、执行、浏览器、Desktop 等架构决策 |
 

--- a/docs/adr/0146-legacy-v136-supervisor-trigger-compatibility.md
+++ b/docs/adr/0146-legacy-v136-supervisor-trigger-compatibility.md
@@ -1,0 +1,84 @@
+# ADR 0146: Exact Legacy v136 Supervisor Trigger Compatibility
+
+Date: 2026-08-28
+
+## Status / 状态
+
+**Accepted.** Schema v138 accepts one exact pre-final Windows Desktop preview history for
+migration v136 and transactionally restores the two missing Supervisor authority triggers to
+their canonical v136 definitions.
+
+**已接受。** Schema v138 精确接受一枚正式固化前的 Windows Desktop 预览版 v136 历史，
+并在事务中把缺少的两枚 Supervisor authority trigger 恢复为正式 v136 定义。
+
+## Context / 背景
+
+An existing user database was healthy, had a contiguous migration ledger through v136, and passed
+SQLite integrity and foreign-key checks, but the current Desktop failed to start because its stored
+v136 checksum was
+`5cccad921f47d44ac37f2206e91b355d55ce221d6c9c61e25e7fc08f1cbb6dbd` instead of the
+canonical checksum
+`6fdf459cf1fe6ae94370118a983598f4bc6e469d383a1f43aa211d863c034e4d`.
+
+Object-by-object inspection showed that the preview was built from an intermediate v136 definition.
+Its v136 schema matched the canonical history except that it did not yet contain:
+
+- `trg_risk_escalation_supervisor_authority_insert`;
+- `trg_host_command_supervisor_envelope_immutable`.
+
+These triggers enforce the binding and immutability of Supervisor authority for risk-escalation and
+host-command envelopes. Treating the preview checksum as generally equivalent without restoring the
+triggers would leave weaker runtime invariants. Deleting or resetting the database would discard
+valid user data and audit history even though the database itself is not corrupt.
+
+现有用户数据库本身健康，migration ledger 连续到 v136，SQLite 完整性与外键检查均通过；
+Desktop 启动失败的原因是其中记录了上述正式固化前 checksum，而不是正式 v136 checksum。
+逐对象比对确认，中间预览版只缺少上列两枚 trigger。仅放行 checksum 而不补齐 trigger 会留下
+较弱的 Supervisor 权限约束；删除或重置数据库则会无故丢失有效业务数据与审计历史。
+
+## Decision / 决策
+
+1. Migration validation accepts the legacy checksum only when the recorded version is exactly 136.
+   Existing validation still requires the exact canonical v136 migration name and a contiguous
+   history.
+2. Schema v138 drops the two named triggers if present and recreates both from the canonical v136
+   definitions in one SQLite migration transaction. Canonical v136/v137 histories and the exact
+   legacy history therefore converge on the same fail-closed schema.
+3. The existing v136 `schema_migrations` row is preserved verbatim. The repair does not rewrite its
+   checksum or claim that the preview executed SQL it did not execute.
+4. The migration does not delete, reset, replace, or reinterpret business rows. If trigger rebuild or
+   ledger append fails, the transaction rolls back as a unit.
+5. Any other v136 checksum, wrong migration name, version gap, newer unsupported schema, or changed
+   history continues to fail closed.
+6. Compatibility tests pin the canonical and legacy checksums, reconstruct the exact two-trigger
+   delta, preserve existing Workspace data, exercise the repaired trigger behavior, and verify the
+   final schema version, ledger preservation, integrity, and foreign-key state.
+
+## Consequences / 结果
+
+- The affected preview database can be upgraded in place without manual SQLite edits or loss of
+  local data.
+- Canonical databases also record v138 and receive an equivalent transactional trigger rebuild;
+  v138 introduces no new business authority or product capability.
+- The exception remains exact, reviewable, and incapable of becoming an arbitrary checksum bypass.
+- A release containing v138 must be validated against a copy of the exact legacy database shape;
+  fresh-profile startup alone is not sufficient upgrade evidence.
+
+## Rejected alternatives / 拒绝方案
+
+- deleting, renaming, or silently resetting the local database;
+- rewriting the recorded v136 checksum to the canonical value;
+- accepting every v136 checksum or validating by migration name alone;
+- accepting the exact preview checksum without restoring both missing triggers;
+- mutating an already published release asset in place.
+
+These alternatives would lose user evidence, falsify migration history, weaken fail-closed
+validation, preserve divergent authority semantics, or violate release immutability.
+
+## Rollback / 回滚
+
+Do not remove or renumber v138 after a build containing it has been published. If another historical
+v136 variant is discovered, first inspect its complete ledger and SQLite schema, then add a
+separately pinned compatibility case and a new forward migration. Never broaden the allowlist at
+runtime, rewrite historical migration rows, or repair an original user database outside a reviewed
+transactional migration.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -788,7 +788,9 @@ SQLite remains the local source of truth. Schema migration `v1` records the lega
 Schema `v134` adds Run-scoped Web search, fetched snapshots, and citations.
 Schema `v135` adds the bounded Standard Code root completion ledger; `v136` adds
 durable risk escalation, grants, consumption and uncertain-execution recovery;
-and `v137` adds immutable Standard Code delivery truth receipts. Every migration
+`v137` adds immutable Standard Code delivery truth receipts; and `v138` accepts
+one exact intermediate Windows preview v136 checksum before rebuilding its two
+missing Supervisor risk-authority triggers. Every migration
 preserves earlier history and fabricates no completion, approval, or verification fact.
 
 ## Standard Code delivery truth gate

--- a/internal/store/clean_install_baseline_generated.go
+++ b/internal/store/clean_install_baseline_generated.go
@@ -3,8 +3,8 @@
 package store
 
 const (
-	cleanInstallBaselineSchemaVersion       = 137
+	cleanInstallBaselineSchemaVersion       = 138
 	cleanInstallBaselineSQLSHA256           = "6bfd5c1bb2ad61983abfc2cb64a48cbf0556864cab6c5d5427075438190772e7"
 	cleanInstallBaselineSchemaSHA256        = "748bc2952328268bb6a1f8dbaedd073e4e4572d2fa18fcc11f4f2be592d944de"
-	cleanInstallBaselineMigrationPlanSHA256 = "0f3d9974cd929a7a99fc3dc8de20b53290724f413276acec0b0098fe4a0154cb"
+	cleanInstallBaselineMigrationPlanSHA256 = "eddd4ef15316b03ef92072bc85bf9ffe687cabf72a65bb7b90950ae9858a4cbc"
 )

--- a/internal/store/migration_v136_test.go
+++ b/internal/store/migration_v136_test.go
@@ -15,6 +15,7 @@ func removeSchemaV136ForTestStatements() []string {
 		"CREATE TABLE approval_session_grants (",
 		"CREATE TABLE approval_session_grants_v135_restore (", 1)
 	prefix := []string{
+		`DELETE FROM schema_migrations WHERE version = 138`,
 		`PRAGMA foreign_keys = OFF`,
 		`PRAGMA legacy_alter_table = ON`,
 		`DROP TRIGGER trg_standard_code_delivery_insert`,

--- a/internal/store/migration_v137_test.go
+++ b/internal/store/migration_v137_test.go
@@ -9,6 +9,7 @@ import (
 
 func removeSchemaV137ForTestStatements() []string {
 	return []string{
+		`DELETE FROM schema_migrations WHERE version = 138`,
 		`DROP TRIGGER trg_standard_code_delivery_insert`,
 		`DROP TRIGGER trg_standard_code_delivery_update_immutable`,
 		`DROP TRIGGER trg_standard_code_delivery_delete_immutable`,

--- a/internal/store/migration_v138.go
+++ b/internal/store/migration_v138.go
@@ -1,0 +1,14 @@
+package store
+
+// An intermediate Windows Desktop preview applied v136 before its two final
+// Supervisor authority triggers were added. Its exact migration checksum is
+// accepted separately; this migration then makes both the legacy and final
+// v136 histories converge on the same fail-closed trigger definitions.
+var legacyRiskEscalationSupervisorTriggerRepairStatements = []string{
+	`DROP TRIGGER IF EXISTS trg_risk_escalation_supervisor_authority_insert;`,
+	`DROP TRIGGER IF EXISTS trg_host_command_supervisor_envelope_immutable;`,
+	requireMigrationTrigger("trg_risk_escalation_supervisor_authority_insert",
+		riskEscalationStatements),
+	requireMigrationTrigger("trg_host_command_supervisor_envelope_immutable",
+		riskEscalationStatements),
+}

--- a/internal/store/migration_v138_test.go
+++ b/internal/store/migration_v138_test.go
@@ -1,0 +1,230 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	canonicalRiskEscalationMigration136Checksum = "6fdf459cf1fe6ae94370118a983598f4bc6e469d383a1f43aa211d863c034e4d"
+	canonicalLegacyRepairMigration138Checksum   = "39c6c11969c53b7e14d50ee5a16868522ca5cd6b476ee16b083eb0ff8a93c1b9"
+)
+
+func legacyWindowsPreviewMigration136Statements(t testing.TB) []string {
+	t.Helper()
+	legacy := make([]string, 0, len(riskEscalationStatements)-2)
+	removed := 0
+	for _, statement := range riskEscalationStatements {
+		trimmed := strings.TrimSpace(statement)
+		if strings.HasPrefix(trimmed,
+			"CREATE TRIGGER trg_risk_escalation_supervisor_authority_insert") ||
+			strings.HasPrefix(trimmed,
+				"CREATE TRIGGER trg_host_command_supervisor_envelope_immutable") {
+			removed++
+			continue
+		}
+		legacy = append(legacy, statement)
+	}
+	if removed != 2 {
+		t.Fatalf("legacy v136 fixture removed %d triggers, want 2", removed)
+	}
+	return legacy
+}
+
+func TestSchemaV138RepairsExactLegacyWindowsPreviewV136(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "legacy-windows-preview-v136.db")
+	state, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.db.ExecContext(ctx, `INSERT INTO workspaces
+		(id, name, root_path, created_at) VALUES (?, ?, ?, ?)`,
+		"legacy-v136-workspace", "Legacy v136 workspace", `C:\legacy-v136-workspace`,
+		"2026-08-25T21:10:38Z"); err != nil {
+		state.Close()
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`DELETE FROM schema_migrations WHERE version = 138`,
+		`DROP TRIGGER trg_standard_code_delivery_insert`,
+		`DROP TRIGGER trg_standard_code_delivery_update_immutable`,
+		`DROP TRIGGER trg_standard_code_delivery_delete_immutable`,
+		`DROP INDEX idx_standard_code_deliveries_run_event`,
+		`DROP TABLE standard_code_deliveries`,
+		`DELETE FROM schema_migrations WHERE version = 137`,
+		`DROP TRIGGER trg_risk_escalation_supervisor_authority_insert`,
+		`DROP TRIGGER trg_host_command_supervisor_envelope_immutable`,
+	} {
+		if _, err := state.db.ExecContext(ctx, statement); err != nil {
+			state.Close()
+			t.Fatalf("restore legacy v136 with %q: %v", statement, err)
+		}
+	}
+	if _, err := state.db.ExecContext(ctx, `UPDATE schema_migrations SET checksum = ?
+		WHERE version = 136`, legacyWindowsPreviewMigration136Checksum); err != nil {
+		state.Close()
+		t.Fatal(err)
+	}
+	if version, err := state.SchemaVersion(ctx); err != nil || version != 136 {
+		state.Close()
+		t.Fatalf("restored schema version=%d want=136 err=%v", version, err)
+	}
+	if err := state.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	plan := migrationPlan()
+	canonicalItem := plan[135]
+	if checksum := migrationChecksum(canonicalItem); checksum !=
+		canonicalRiskEscalationMigration136Checksum {
+		t.Fatalf("canonical v136 checksum drifted: got %s want %s", checksum,
+			canonicalRiskEscalationMigration136Checksum)
+	}
+	legacyItem := canonicalItem
+	legacyItem.Statements = legacyWindowsPreviewMigration136Statements(t)
+	if checksum := migrationChecksum(legacyItem); checksum !=
+		legacyWindowsPreviewMigration136Checksum {
+		t.Fatalf("legacy v136 fixture checksum=%s want=%s", checksum,
+			legacyWindowsPreviewMigration136Checksum)
+	}
+	if checksum := migrationChecksum(plan[137]); checksum !=
+		canonicalLegacyRepairMigration138Checksum {
+		t.Fatalf("canonical v138 checksum drifted: got %s want %s", checksum,
+			canonicalLegacyRepairMigration138Checksum)
+	}
+	if !acceptedMigrationChecksum(canonicalItem, legacyWindowsPreviewMigration136Checksum) {
+		t.Fatal("exact legacy v136 checksum was not accepted")
+	}
+	if acceptedMigrationChecksum(plan[134], legacyWindowsPreviewMigration136Checksum) ||
+		acceptedMigrationChecksum(canonicalItem, strings.Repeat("0", 64)) {
+		t.Fatal("legacy v136 compatibility widened beyond the exact version and checksum")
+	}
+	applied := make(map[int]appliedMigration, 136)
+	for _, item := range plan[:136] {
+		applied[item.Version] = appliedMigration{Name: item.Name,
+			Checksum: migrationChecksum(item)}
+	}
+	applied[136] = appliedMigration{Name: canonicalItem.Name,
+		Checksum: legacyWindowsPreviewMigration136Checksum}
+	if err := validateMigrationPlan(plan, applied); err != nil {
+		t.Fatalf("exact legacy v136 plan was rejected: %v", err)
+	}
+	applied[136] = appliedMigration{Name: "wrong name",
+		Checksum: legacyWindowsPreviewMigration136Checksum}
+	if err := validateMigrationPlan(plan, applied); err == nil {
+		t.Fatal("legacy v136 checksum was accepted under the wrong migration name")
+	}
+
+	upgraded, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upgraded.Close()
+	if version, err := upgraded.SchemaVersion(ctx); err != nil || version != LatestSchemaVersion {
+		t.Fatalf("upgraded schema version=%d want=%d err=%v", version,
+			LatestSchemaVersion, err)
+	}
+	var recordedChecksum string
+	if err := upgraded.db.QueryRowContext(ctx, `SELECT checksum FROM schema_migrations
+		WHERE version = 136`).Scan(&recordedChecksum); err != nil ||
+		recordedChecksum != legacyWindowsPreviewMigration136Checksum {
+		t.Fatalf("legacy v136 ledger was rewritten: checksum=%q err=%v",
+			recordedChecksum, err)
+	}
+	var workspaceName, workspaceRoot string
+	if err := upgraded.db.QueryRowContext(ctx, `SELECT name, root_path FROM workspaces
+		WHERE id = ?`, "legacy-v136-workspace").Scan(&workspaceName, &workspaceRoot); err != nil ||
+		workspaceName != "Legacy v136 workspace" || workspaceRoot != `C:\legacy-v136-workspace` {
+		t.Fatalf("legacy v136 application data changed: name=%q root=%q err=%v",
+			workspaceName, workspaceRoot, err)
+	}
+	for _, name := range []string{
+		"trg_risk_escalation_supervisor_authority_insert",
+		"trg_host_command_supervisor_envelope_immutable",
+	} {
+		var sql string
+		err := upgraded.db.QueryRowContext(ctx, `SELECT sql FROM sqlite_master
+			WHERE type = 'trigger' AND name = ?`, name).Scan(&sql)
+		got := strings.TrimSuffix(strings.TrimSpace(sql), ";")
+		want := strings.TrimSuffix(strings.TrimSpace(requireMigrationTrigger(name,
+			riskEscalationStatements)), ";")
+		if err != nil || got != want {
+			t.Fatalf("repaired trigger %s differs from canonical v136 SQL: %q err=%v",
+				name, sql, err)
+		}
+	}
+	assertNoForeignKeyViolations(t, upgraded.db)
+	assertSchemaV138SupervisorTriggerBehavior(t, ctx, upgraded)
+}
+
+func assertSchemaV138SupervisorTriggerBehavior(t testing.TB, ctx context.Context,
+	state *SQLiteStore,
+) {
+	t.Helper()
+	rows, err := state.db.QueryContext(ctx, `SELECT name FROM sqlite_master
+		WHERE type = 'trigger' AND tbl_name = 'run_supervisor_tool_calls'
+			AND name NOT IN (
+				'trg_risk_escalation_supervisor_authority_insert',
+				'trg_host_command_supervisor_envelope_immutable'
+			)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var unrelated []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			rows.Close()
+			t.Fatal(err)
+		}
+		unrelated = append(unrelated, name)
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range unrelated {
+		quoted := strings.ReplaceAll(name, `"`, `""`)
+		if _, err := state.db.ExecContext(ctx, `DROP TRIGGER "`+quoted+`"`); err != nil {
+			t.Fatalf("drop unrelated Supervisor trigger %s: %v", name, err)
+		}
+	}
+	if _, err := state.db.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if _, err := state.db.ExecContext(ctx, `PRAGMA foreign_keys = ON`); err != nil {
+			t.Errorf("restore foreign key enforcement: %v", err)
+		}
+	}()
+
+	insert := `INSERT INTO run_supervisor_tool_calls
+		(run_id, turn, attempt_id, round, position, model_attempt, call_id,
+		 tool_name, payload_json, authority_json, status, created_at)
+		VALUES (?, 1, ?, 1, ?, 1, ?, 'host_command_propose', ?, ?, 'pending', ?)`
+	if _, err := state.db.ExecContext(ctx, insert,
+		"v138-trigger-run", "v138-trigger-attempt", 1, "v138-invalid-authority",
+		`{"version":"risk_escalation.v1"}`, "", "2026-08-28T00:00:00Z"); err == nil ||
+		!strings.Contains(err.Error(),
+			"risk escalation Supervisor authority does not match its protocol") {
+		t.Fatalf("mismatched risk authority was not rejected by repaired trigger: %v", err)
+	}
+	if _, err := state.db.ExecContext(ctx, insert,
+		"v138-trigger-run", "v138-trigger-attempt", 1, "v138-valid-authority",
+		`{"version":"risk_escalation.v1"}`, `{}`, "2026-08-28T00:00:00Z"); err != nil {
+		t.Fatalf("valid risk authority was rejected by repaired trigger: %v", err)
+	}
+	if _, err := state.db.ExecContext(ctx, `UPDATE run_supervisor_tool_calls
+		SET payload_json = ? WHERE run_id = ? AND call_id = ?`,
+		`{"version":"risk_escalation.v1","changed":true}`,
+		"v138-trigger-run", "v138-valid-authority"); err == nil ||
+		!strings.Contains(err.Error(), "host command Supervisor envelope is immutable") {
+		t.Fatalf("host command envelope mutation was not rejected by repaired trigger: %v", err)
+	}
+	if _, err := state.db.ExecContext(ctx, `DELETE FROM run_supervisor_tool_calls
+		WHERE run_id = ?`, "v138-trigger-run"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-const LatestSchemaVersion = 137
+const LatestSchemaVersion = 138
 
 type migration struct {
 	Version            int
@@ -8965,19 +8965,23 @@ func validateMigrationPlan(migrations []migration, applied map[int]appliedMigrat
 }
 
 const (
-	legacyWindowsPreviewMigration30Checksum = "bef87a078e337c7c78f020b0470b5d3c8a889a42c3f5993ef62f16e761018ae7"
-	legacyWindowsPreviewMigration97Checksum = "844427411efc98247ebf521badb98a8c96e3a17b8aa5c7d429b7192d4dcad83b"
+	legacyWindowsPreviewMigration30Checksum  = "bef87a078e337c7c78f020b0470b5d3c8a889a42c3f5993ef62f16e761018ae7"
+	legacyWindowsPreviewMigration97Checksum  = "844427411efc98247ebf521badb98a8c96e3a17b8aa5c7d429b7192d4dcad83b"
+	legacyWindowsPreviewMigration136Checksum = "5cccad921f47d44ac37f2206e91b355d55ce221d6c9c61e25e7fc08f1cbb6dbd"
 )
 
 func acceptedMigrationChecksum(item migration, recorded string) bool {
 	if recorded == migrationChecksum(item) {
 		return true
 	}
-	// Two Windows preview profiles recorded these exact released histories.
-	// Migration v125 repairs the legacy v97 cleanup trigger after validation.
-	// The compatibility path is immutable and cannot be widened at runtime.
+	// Windows preview profiles recorded these exact released histories.
+	// Migration v125 repairs the legacy v97 cleanup trigger after validation;
+	// v138 repairs the two Supervisor authority triggers absent from the pinned
+	// intermediate v136 history. The compatibility path remains exact and cannot
+	// be widened at runtime.
 	return (item.Version == 30 && recorded == legacyWindowsPreviewMigration30Checksum) ||
-		(item.Version == 97 && recorded == legacyWindowsPreviewMigration97Checksum)
+		(item.Version == 97 && recorded == legacyWindowsPreviewMigration97Checksum) ||
+		(item.Version == 136 && recorded == legacyWindowsPreviewMigration136Checksum)
 }
 
 func migrationChecksum(item migration) string {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -378,6 +378,7 @@ func migrationPlan() []migration {
 		{Version: 135, Name: "bounded Standard Code Supervisor completion and Code Intel call ledger", Statements: standardCodeSupervisorStatements, DisableForeignKeys: true},
 		{Version: 136, Name: "durable exact risk escalation approvals and bounded grants", Statements: riskEscalationStatements},
 		{Version: 137, Name: "immutable Standard Code delivery truth receipts", Statements: standardCodeDeliveryStatements},
+		{Version: 138, Name: "legacy v136 Supervisor authority trigger repair", Statements: legacyRiskEscalationSupervisorTriggerRepairStatements},
 	}
 }
 

--- a/scripts/smoke-desktop-operator-preview.ps1
+++ b/scripts/smoke-desktop-operator-preview.ps1
@@ -1,11 +1,105 @@
 [CmdletBinding()]
 param(
     [string]$BinaryPath = "build/desktop/TraverseBoard.exe",
+    [string]$SeedDatabasePath = "",
     [ValidateRange(3, 60)][int]$StartupTimeoutSeconds = 15,
     [switch]$KeepData
 )
 
 $ErrorActionPreference = "Stop"
+
+function Find-SqlitePython {
+    $candidates = @(
+        @{ Name = "py"; Prefix = @("-3") },
+        @{ Name = "python"; Prefix = @() },
+        @{ Name = "python3"; Prefix = @() }
+    )
+    foreach ($candidate in $candidates) {
+        $command = Get-Command $candidate.Name -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if ($null -eq $command) {
+            continue
+        }
+        $arguments = @($candidate.Prefix) + @(
+            "-c",
+            'import sqlite3; print("traverse-board-sqlite-ready")'
+        )
+        $probe = @(& $command.Source $arguments 2>&1)
+        $probeExitCode = $LASTEXITCODE
+        $probeText = (($probe | ForEach-Object { $_.ToString() }) -join "`n").Trim()
+        if ($probeExitCode -eq 0 -and $probeText -ceq "traverse-board-sqlite-ready") {
+            return [pscustomobject]@{
+                Executable = $command.Source
+                Prefix = @($candidate.Prefix)
+            }
+        }
+    }
+    throw "Seeded Desktop smoke requires Python with the standard sqlite3 module"
+}
+
+function Read-DatabaseSchemaVersion {
+    param(
+        [Parameter(Mandatory = $true)][string]$DatabasePath,
+        [Parameter(Mandatory = $true)]$PythonRuntime,
+        [Parameter(Mandatory = $true)][string]$Description,
+        [switch]$Immutable
+    )
+
+    $query = @'
+import pathlib
+import sqlite3
+import sys
+
+database = pathlib.Path(sys.argv[1]).resolve()
+uri = database.as_uri() + "?mode=ro"
+if sys.argv[2] == "true":
+    uri += "&immutable=1"
+connection = sqlite3.connect(uri, uri=True, timeout=1.0)
+try:
+    minimum, maximum, count = connection.execute(
+        "SELECT MIN(version), MAX(version), COUNT(*) FROM schema_migrations"
+    ).fetchone()
+    if minimum != 1 or not isinstance(maximum, int) or count != maximum:
+        raise RuntimeError("schema_migrations is not a contiguous v1..vN ledger")
+    print(maximum)
+finally:
+    connection.close()
+'@
+    $arguments = @($PythonRuntime.Prefix) + @(
+        "-c",
+        $query,
+        $DatabasePath,
+        $Immutable.IsPresent.ToString().ToLowerInvariant()
+    )
+    $result = @(& $PythonRuntime.Executable $arguments 2>&1)
+    $queryExitCode = $LASTEXITCODE
+    $resultText = (($result | ForEach-Object { $_.ToString() }) -join "`n").Trim()
+    if ($queryExitCode -ne 0) {
+        throw "Could not read $Description schema version in read-only mode: $resultText"
+    }
+    if (-not [regex]::IsMatch($resultText, '^[1-9][0-9]*$')) {
+        throw "Could not parse $Description schema version: $resultText"
+    }
+    return [int]::Parse($resultText, [System.Globalization.CultureInfo]::InvariantCulture)
+}
+
+function Read-LatestSchemaVersion {
+    param([Parameter(Mandatory = $true)][string]$RepositoryRoot)
+
+    $migrationSource = Join-Path $RepositoryRoot "internal/store/migrations.go"
+    if (-not (Test-Path -LiteralPath $migrationSource -PathType Leaf)) {
+        throw "Latest schema version source is missing: $migrationSource"
+    }
+    $source = [System.IO.File]::ReadAllText($migrationSource)
+    $matches = [regex]::Matches($source,
+        '(?m)^const LatestSchemaVersion = (?<version>[1-9][0-9]*)\r?$')
+    if ($matches.Count -ne 1) {
+        throw "LatestSchemaVersion must have one strict declaration in: $migrationSource"
+    }
+    return [int]::Parse($matches[0].Groups['version'].Value,
+        [System.Globalization.CultureInfo]::InvariantCulture)
+}
+
 $repositoryRoot = [System.IO.Path]::GetFullPath((Split-Path -Parent $PSScriptRoot))
 $binary = if ([System.IO.Path]::IsPathRooted($BinaryPath)) {
     [System.IO.Path]::GetFullPath($BinaryPath)
@@ -24,15 +118,65 @@ if (-not (Test-Path -LiteralPath $binary -PathType Leaf)) {
     throw "Desktop binary is missing: $binary"
 }
 
+$seedDatabase = $null
+$seedDatabaseHash = $null
+$seedSchemaVersion = $null
+$latestSchemaVersion = $null
+$sqlitePython = $null
+if (-not [string]::IsNullOrWhiteSpace($SeedDatabasePath)) {
+    $seedDatabase = if ([System.IO.Path]::IsPathRooted($SeedDatabasePath)) {
+        [System.IO.Path]::GetFullPath($SeedDatabasePath)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path $repositoryRoot $SeedDatabasePath))
+    }
+    if (-not $seedDatabase.StartsWith($repositoryPrefix,
+            [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Desktop smoke seed database must remain inside the repository: $seedDatabase"
+    }
+    if (-not (Test-Path -LiteralPath $seedDatabase -PathType Leaf)) {
+        throw "Desktop smoke seed database is missing: $seedDatabase"
+    }
+    foreach ($suffix in @("-wal", "-shm", "-journal")) {
+        $sidecar = $seedDatabase + $suffix
+        if (Test-Path -LiteralPath $sidecar) {
+            throw "Desktop smoke seed database must be quiescent; sidecar is present: $sidecar"
+        }
+    }
+    $seedDatabaseHash = (Get-FileHash -LiteralPath $seedDatabase -Algorithm SHA256).Hash
+    $latestSchemaVersion = Read-LatestSchemaVersion -RepositoryRoot $repositoryRoot
+    $sqlitePython = Find-SqlitePython
+    $seedSchemaVersion = Read-DatabaseSchemaVersion -DatabasePath $seedDatabase `
+        -PythonRuntime $sqlitePython -Description "seed database" -Immutable
+    $seedDatabaseHashAfterRead = (Get-FileHash -LiteralPath $seedDatabase -Algorithm SHA256).Hash
+    if ($seedDatabaseHash -cne $seedDatabaseHashAfterRead) {
+        throw "Desktop smoke seed database changed while its schema version was inspected"
+    }
+    if ($seedSchemaVersion -ge $latestSchemaVersion) {
+        throw "Desktop smoke seed schema v$seedSchemaVersion must be older than repository schema v$latestSchemaVersion"
+    }
+}
+
 $temporaryRoot = Join-Path $repositoryRoot ".tmp"
 $isolatedHome = Join-Path $temporaryRoot ("desktop-direct-launch-smoke-" + [guid]::NewGuid().ToString("N"))
 $database = Join-Path $isolatedHome "cyberagent.db"
 [System.IO.Directory]::CreateDirectory($isolatedHome) | Out-Null
 $previousHome = $env:CYBERAGENT_HOME
 $process = $null
+$startedProcessID = $null
+$startupSucceeded = $false
+$observedSchemaVersion = $null
+$lastDatabaseProbeError = $null
 try {
+    if ($null -ne $seedDatabase) {
+        [System.IO.File]::Copy($seedDatabase, $database, $false)
+        $copiedDatabaseHash = (Get-FileHash -LiteralPath $database -Algorithm SHA256).Hash
+        if ($copiedDatabaseHash -cne $seedDatabaseHash) {
+            throw "Isolated Desktop smoke database does not match the seed before launch"
+        }
+    }
     $env:CYBERAGENT_HOME = $isolatedHome
     $process = Start-Process -FilePath $binary -PassThru
+    $startedProcessID = $process.Id
     $deadline = [DateTime]::UtcNow.AddSeconds($StartupTimeoutSeconds)
     while ([DateTime]::UtcNow -lt $deadline) {
         $process.Refresh()
@@ -40,42 +184,98 @@ try {
             throw "Desktop exited during startup with code $($process.ExitCode)"
         }
         if (Test-Path -LiteralPath $database -PathType Leaf) {
+            if ($null -ne $seedDatabase) {
+                try {
+                    $observedSchemaVersion = Read-DatabaseSchemaVersion -DatabasePath $database `
+                        -PythonRuntime $sqlitePython -Description "isolated database"
+                    $lastDatabaseProbeError = $null
+                }
+                catch {
+                    $lastDatabaseProbeError = $_.Exception.Message
+                    Start-Sleep -Milliseconds 250
+                    continue
+                }
+                if ($observedSchemaVersion -gt $latestSchemaVersion) {
+                    throw "Desktop upgraded the isolated database beyond repository schema v$latestSchemaVersion to v$observedSchemaVersion"
+                }
+                if ($observedSchemaVersion -lt $latestSchemaVersion) {
+                    Start-Sleep -Milliseconds 250
+                    continue
+                }
+            }
             Start-Sleep -Milliseconds 750
             $process.Refresh()
             if ($process.HasExited) {
                 throw "Desktop exited after creating its local store with code $($process.ExitCode)"
             }
-            Write-Output "desktop_direct_launch_smoke: pass"
-            Write-Output "desktop_direct_launch_pid: $($process.Id)"
-            Write-Output "desktop_direct_launch_store_created: true"
+            if ($null -ne $seedDatabase) {
+                $confirmedSchemaVersion = Read-DatabaseSchemaVersion -DatabasePath $database `
+                    -PythonRuntime $sqlitePython -Description "isolated database"
+                if ($confirmedSchemaVersion -ne $latestSchemaVersion -or
+                        $confirmedSchemaVersion -le $seedSchemaVersion) {
+                    throw "Desktop database upgrade was not stable: seed=v$seedSchemaVersion expected=v$latestSchemaVersion observed=v$confirmedSchemaVersion"
+                }
+                $observedSchemaVersion = $confirmedSchemaVersion
+            }
+            $startupSucceeded = $true
             break
         }
         Start-Sleep -Milliseconds 100
     }
-    if (-not (Test-Path -LiteralPath $database -PathType Leaf)) {
+    if (-not $startupSucceeded -and $null -ne $seedDatabase) {
+        $observed = if ($null -eq $observedSchemaVersion) { "unreadable" } else { "v$observedSchemaVersion" }
+        $probeDetail = if ([string]::IsNullOrWhiteSpace($lastDatabaseProbeError)) {
+            "none"
+        } else {
+            $lastDatabaseProbeError
+        }
+        throw "Desktop did not upgrade the isolated database before the startup deadline: seed=v$seedSchemaVersion expected=v$latestSchemaVersion observed=$observed last_probe_error=$probeDetail"
+    }
+    if (-not $startupSucceeded) {
         throw "Desktop did not create its isolated local store before the startup deadline"
     }
 }
 finally {
-    $env:CYBERAGENT_HOME = $previousHome
-    if ($null -ne $process) {
-        $process.Refresh()
-        if (-not $process.HasExited) {
-            $null = $process.CloseMainWindow()
-            if (-not $process.WaitForExit(5000)) {
-                Stop-Process -Id $process.Id -Force
-                $process.WaitForExit()
+    try {
+        $env:CYBERAGENT_HOME = $previousHome
+        if ($null -ne $process) {
+            $process.Refresh()
+            if (-not $process.HasExited) {
+                $null = $process.CloseMainWindow()
+                if (-not $process.WaitForExit(5000)) {
+                    Stop-Process -Id $process.Id -Force
+                    $process.WaitForExit()
+                }
+            }
+            $process.Dispose()
+        }
+        if (-not $KeepData -and (Test-Path -LiteralPath $isolatedHome)) {
+            $resolvedHome = [System.IO.Path]::GetFullPath($isolatedHome)
+            $resolvedTemporaryRoot = [System.IO.Path]::GetFullPath($temporaryRoot).TrimEnd('\') + '\'
+            if (-not $resolvedHome.StartsWith($resolvedTemporaryRoot,
+                    [System.StringComparison]::OrdinalIgnoreCase)) {
+                throw "Refusing to clean a Desktop smoke directory outside the repository temporary root"
+            }
+            Remove-Item -LiteralPath $resolvedHome -Recurse -Force
+        }
+    }
+    finally {
+        if ($null -ne $seedDatabase) {
+            $seedDatabaseHashAfterSmoke = (Get-FileHash -LiteralPath $seedDatabase -Algorithm SHA256).Hash
+            if ($seedDatabaseHash -cne $seedDatabaseHashAfterSmoke) {
+                throw "Desktop smoke seed database was modified"
             }
         }
-        $process.Dispose()
     }
-    if (-not $KeepData -and (Test-Path -LiteralPath $isolatedHome)) {
-        $resolvedHome = [System.IO.Path]::GetFullPath($isolatedHome)
-        $resolvedTemporaryRoot = [System.IO.Path]::GetFullPath($temporaryRoot).TrimEnd('\') + '\'
-        if (-not $resolvedHome.StartsWith($resolvedTemporaryRoot,
-                [System.StringComparison]::OrdinalIgnoreCase)) {
-            throw "Refusing to clean a Desktop smoke directory outside the repository temporary root"
-        }
-        Remove-Item -LiteralPath $resolvedHome -Recurse -Force
-    }
+}
+
+Write-Output "desktop_direct_launch_smoke: pass"
+Write-Output "desktop_direct_launch_pid: $startedProcessID"
+Write-Output "desktop_direct_launch_store_created: true"
+Write-Output ("desktop_direct_launch_seeded_database: $($null -ne $seedDatabase)".ToLowerInvariant())
+if ($null -ne $seedDatabase) {
+    Write-Output "desktop_direct_launch_seed_schema_version: $seedSchemaVersion"
+    Write-Output "desktop_direct_launch_observed_schema_version: $observedSchemaVersion"
+    Write-Output "desktop_direct_launch_expected_schema_version: $latestSchemaVersion"
+    Write-Output "desktop_direct_launch_seed_source_unchanged: true"
 }

--- a/scripts/smoke-desktop-operator-preview.ps1
+++ b/scripts/smoke-desktop-operator-preview.ps1
@@ -8,6 +8,30 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+function Invoke-NativeCommandCapture {
+    param(
+        [Parameter(Mandatory = $true)][string]$Executable,
+        [Parameter(Mandatory = $true)][object[]]$Arguments
+    )
+
+    # Windows PowerShell 5.1 turns redirected native stderr into an ErrorRecord.
+    # With the script-wide Stop preference that would become a terminating error
+    # before callers can inspect LASTEXITCODE or try the next executable.
+    $savedErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $capturedOutput = @(& $Executable $Arguments 2>&1)
+        $capturedExitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $savedErrorActionPreference
+    }
+    return [pscustomobject]@{
+        Output = @($capturedOutput)
+        ExitCode = $capturedExitCode
+    }
+}
+
 function Find-SqlitePython {
     $candidates = @(
         @{ Name = "py"; Prefix = @("-3") },
@@ -22,12 +46,11 @@ function Find-SqlitePython {
         }
         $arguments = @($candidate.Prefix) + @(
             "-c",
-            'import sqlite3; print("traverse-board-sqlite-ready")'
+            "import sqlite3; print('traverse-board-sqlite-ready')"
         )
-        $probe = @(& $command.Source $arguments 2>&1)
-        $probeExitCode = $LASTEXITCODE
-        $probeText = (($probe | ForEach-Object { $_.ToString() }) -join "`n").Trim()
-        if ($probeExitCode -eq 0 -and $probeText -ceq "traverse-board-sqlite-ready") {
+        $probe = Invoke-NativeCommandCapture -Executable $command.Source -Arguments $arguments
+        $probeText = (($probe.Output | ForEach-Object { $_.ToString() }) -join "`n").Trim()
+        if ($probe.ExitCode -eq 0 -and $probeText -ceq "traverse-board-sqlite-ready") {
             return [pscustomobject]@{
                 Executable = $command.Source
                 Prefix = @($candidate.Prefix)
@@ -65,18 +88,10 @@ try:
 finally:
     connection.close()
 '@
-    $arguments = @($PythonRuntime.Prefix) + @(
-        "-c",
-        $query,
-        $DatabasePath,
-        $Immutable.IsPresent.ToString().ToLowerInvariant()
-    )
-    $result = @(& $PythonRuntime.Executable $arguments 2>&1)
-    $queryExitCode = $LASTEXITCODE
-    $resultText = (($result | ForEach-Object { $_.ToString() }) -join "`n").Trim()
-    if ($queryExitCode -ne 0) {
-        throw "Could not read $Description schema version in read-only mode: $resultText"
-    }
+    $resultText = Invoke-SqlitePython -PythonRuntime $PythonRuntime -Script $query `
+        -ScriptArguments @($DatabasePath,
+            $Immutable.IsPresent.ToString().ToLowerInvariant()) `
+        -Description "Read $Description schema version in read-only mode"
     if (-not [regex]::IsMatch($resultText, '^[1-9][0-9]*$')) {
         throw "Could not parse $Description schema version: $resultText"
     }
@@ -98,6 +113,327 @@ function Read-LatestSchemaVersion {
     }
     return [int]::Parse($matches[0].Groups['version'].Value,
         [System.Globalization.CultureInfo]::InvariantCulture)
+}
+
+function Invoke-SqlitePython {
+    param(
+        [Parameter(Mandatory = $true)]$PythonRuntime,
+        [Parameter(Mandatory = $true)][string]$Script,
+        [string[]]$ScriptArguments = @(),
+        [Parameter(Mandatory = $true)][string]$Description
+    )
+
+    # WinPS 5.1 strips literal double quotes from a native -c argument. Passing
+    # a single-quoted base64 bootstrap keeps multiline Python identical on 5.1
+    # and pwsh without shell-specific command-line reparsing.
+    $encodedScript = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Script))
+    $bootstrap = "import base64;exec(base64.b64decode('$encodedScript'))"
+    $arguments = @($PythonRuntime.Prefix) + @("-c", $bootstrap) + @($ScriptArguments)
+    $result = Invoke-NativeCommandCapture -Executable $PythonRuntime.Executable `
+        -Arguments $arguments
+    $resultText = (($result.Output | ForEach-Object { $_.ToString() }) -join "`n").Trim()
+    if ($result.ExitCode -ne 0) {
+        throw "$Description failed: $resultText"
+    }
+    return $resultText
+}
+
+function Add-IsolatedWorkspaceSentinel {
+    param(
+        [Parameter(Mandatory = $true)][string]$DatabasePath,
+        [Parameter(Mandatory = $true)]$PythonRuntime,
+        [Parameter(Mandatory = $true)][string]$SentinelID,
+        [Parameter(Mandatory = $true)][string]$SentinelName,
+        [Parameter(Mandatory = $true)][string]$SentinelRoot,
+        [Parameter(Mandatory = $true)][string]$SentinelCreatedAt
+    )
+
+    $script = @'
+import pathlib
+import sqlite3
+import sys
+
+database = pathlib.Path(sys.argv[1]).resolve()
+connection = sqlite3.connect(str(database), timeout=5.0)
+try:
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute("BEGIN IMMEDIATE")
+    if connection.execute(
+        "SELECT COUNT(*) FROM workspaces WHERE id = ? OR name = ?",
+        (sys.argv[2], sys.argv[3]),
+    ).fetchone()[0] != 0:
+        raise RuntimeError("workspace sentinel unexpectedly collides with seed data")
+    connection.execute(
+        "INSERT INTO workspaces (id, name, root_path, created_at) VALUES (?, ?, ?, ?)",
+        (sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]),
+    )
+    connection.commit()
+    print("traverse-board-sentinel-ready")
+except Exception:
+    if connection.in_transaction:
+        connection.rollback()
+    raise
+finally:
+    connection.close()
+'@
+    $resultText = Invoke-SqlitePython -PythonRuntime $PythonRuntime -Script $script `
+        -ScriptArguments @($DatabasePath, $SentinelID, $SentinelName, $SentinelRoot,
+            $SentinelCreatedAt) -Description "Prepare isolated Desktop smoke sentinel"
+    if ($resultText -cne "traverse-board-sentinel-ready") {
+        throw "Could not confirm the isolated Desktop smoke sentinel: $resultText"
+    }
+}
+
+function Read-DatabaseUpgradeSnapshot {
+    param(
+        [Parameter(Mandatory = $true)][string]$DatabasePath,
+        [Parameter(Mandatory = $true)]$PythonRuntime,
+        [Parameter(Mandatory = $true)][string]$SentinelID,
+        [Parameter(Mandatory = $true)][string]$Description
+    )
+
+    $script = @'
+import hashlib
+import json
+import pathlib
+import sqlite3
+import struct
+import sys
+
+def quote_identifier(value):
+    return '"' + value.replace('"', '""') + '"'
+
+def append_value(digest, value):
+    if value is None:
+        kind, payload = b"n", b""
+    elif isinstance(value, int):
+        kind, payload = b"i", str(value).encode("ascii")
+    elif isinstance(value, float):
+        kind, payload = b"f", struct.pack(">d", value)
+    elif isinstance(value, str):
+        kind, payload = b"t", value.encode("utf-8")
+    elif isinstance(value, (bytes, bytearray, memoryview)):
+        kind, payload = b"b", bytes(value)
+    else:
+        raise TypeError("unsupported SQLite value type: " + type(value).__name__)
+    digest.update(kind)
+    digest.update(struct.pack(">Q", len(payload)))
+    digest.update(payload)
+
+def row_digest(row):
+    digest = hashlib.sha256()
+    digest.update(struct.pack(">Q", len(row)))
+    for value in row:
+        append_value(digest, value)
+    return digest.digest()
+
+database = pathlib.Path(sys.argv[1]).resolve()
+uri = database.as_uri() + "?mode=ro"
+connection = sqlite3.connect(uri, uri=True, timeout=2.0)
+try:
+    connection.execute("BEGIN")
+    ledger = [
+        {"version": row[0], "name": row[1], "checksum": row[2]}
+        for row in connection.execute(
+            "SELECT version, name, checksum FROM schema_migrations ORDER BY version"
+        )
+    ]
+    versions = [item["version"] for item in ledger]
+    if not versions or versions != list(range(1, versions[-1] + 1)):
+        raise RuntimeError("schema_migrations is not a contiguous v1..vN ledger")
+
+    table_names = [
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type = 'table' AND name NOT LIKE 'sqlite_%' "
+            "AND name <> 'schema_migrations' ORDER BY name"
+        )
+    ]
+    business_tables = []
+    for table_name in table_names:
+        hashes = [
+            row_digest(row)
+            for row in connection.execute("SELECT * FROM " + quote_identifier(table_name))
+        ]
+        hashes.sort()
+        content = hashlib.sha256()
+        content.update(struct.pack(">Q", len(hashes)))
+        for item in hashes:
+            content.update(item)
+        business_tables.append({
+            "name": table_name,
+            "row_count": len(hashes),
+            "content_sha256": content.hexdigest(),
+        })
+
+    sentinel = connection.execute(
+        "SELECT id, name, root_path, created_at FROM workspaces WHERE id = ?",
+        (sys.argv[2],),
+    ).fetchone()
+    trigger_names = (
+        "trg_risk_escalation_supervisor_authority_insert",
+        "trg_host_command_supervisor_envelope_immutable",
+    )
+    triggers = []
+    for trigger_name in trigger_names:
+        row = connection.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = ?",
+            (trigger_name,),
+        ).fetchone()
+        triggers.append({"name": trigger_name, "sql": None if row is None else row[0]})
+
+    integrity = [row[0] for row in connection.execute("PRAGMA integrity_check")]
+    foreign_key_violations = sum(1 for _ in connection.execute("PRAGMA foreign_key_check"))
+    snapshot = {
+        "schema_version": versions[-1],
+        "ledger": ledger,
+        "business_tables": business_tables,
+        "sentinel": None if sentinel is None else {
+            "id": sentinel[0],
+            "name": sentinel[1],
+            "root_path": sentinel[2],
+            "created_at_text": "sqlite-text:" + sentinel[3],
+        },
+        "integrity_check": integrity,
+        "foreign_key_violation_count": foreign_key_violations,
+        "triggers": triggers,
+    }
+    print(json.dumps(snapshot, sort_keys=True, separators=(",", ":"), ensure_ascii=True))
+finally:
+    if connection.in_transaction:
+        connection.rollback()
+    connection.close()
+'@
+    $resultText = Invoke-SqlitePython -PythonRuntime $PythonRuntime -Script $script `
+        -ScriptArguments @($DatabasePath, $SentinelID) -Description $Description
+    try {
+        return $resultText | ConvertFrom-Json
+    }
+    catch {
+        throw "Could not parse ${Description}: $($_.Exception.Message)"
+    }
+}
+
+function Normalize-TriggerSQL {
+    param([Parameter(Mandatory = $true)][string]$SQL)
+
+    $normalized = $SQL.Trim()
+    if ($normalized.EndsWith(";", [System.StringComparison]::Ordinal)) {
+        $normalized = $normalized.Substring(0, $normalized.Length - 1).TrimEnd()
+    }
+    return $normalized.Replace("`r`n", "`n").Replace("`r", "`n")
+}
+
+function Read-CanonicalRepairTriggers {
+    param([Parameter(Mandatory = $true)][string]$RepositoryRoot)
+
+    $baselinePath = Join-Path $RepositoryRoot "internal/store/clean_install_baseline.sql"
+    if (-not (Test-Path -LiteralPath $baselinePath -PathType Leaf)) {
+        throw "Clean-install baseline is missing: $baselinePath"
+    }
+    $source = [System.IO.File]::ReadAllText($baselinePath)
+    $blocks = [regex]::Split($source,
+        '(?m)^-- traverse-board-clean-install-object-boundary --\r?$')
+    $result = @{}
+    foreach ($name in @(
+            "trg_risk_escalation_supervisor_authority_insert",
+            "trg_host_command_supervisor_envelope_immutable")) {
+        $pattern = '^CREATE TRIGGER ' + [regex]::Escape($name) + '(?:\s|$)'
+        $matches = @($blocks | Where-Object {
+                [regex]::IsMatch($_.Trim(), $pattern)
+            })
+        if ($matches.Count -ne 1) {
+            throw "Clean-install baseline must contain one canonical trigger: $name"
+        }
+        $result[$name] = Normalize-TriggerSQL -SQL $matches[0]
+    }
+    return $result
+}
+
+function Assert-SeededUpgradePreserved {
+    param(
+        [Parameter(Mandatory = $true)]$Before,
+        [Parameter(Mandatory = $true)]$After,
+        [Parameter(Mandatory = $true)][int]$ExpectedSchemaVersion,
+        [Parameter(Mandatory = $true)][hashtable]$ExpectedTriggerSQL,
+        [Parameter(Mandatory = $true)][string]$SentinelID,
+        [Parameter(Mandatory = $true)][string]$SentinelName,
+        [Parameter(Mandatory = $true)][string]$SentinelRoot,
+        [Parameter(Mandatory = $true)][string]$SentinelCreatedAt
+    )
+
+    if ([int]$After.schema_version -ne $ExpectedSchemaVersion -or
+            [int]$After.schema_version -le [int]$Before.schema_version) {
+        throw "Desktop database upgrade was not complete: seed=v$($Before.schema_version) expected=v$ExpectedSchemaVersion observed=v$($After.schema_version)"
+    }
+
+    $beforeLedger = @($Before.ledger)
+    $afterLedger = @($After.ledger)
+    if ($afterLedger.Count -ne $ExpectedSchemaVersion -or
+            $beforeLedger.Count -ne [int]$Before.schema_version) {
+        throw "Desktop database migration ledger length is invalid after upgrade"
+    }
+    for ($index = 0; $index -lt $beforeLedger.Count; $index++) {
+        $expected = $beforeLedger[$index]
+        $observed = $afterLedger[$index]
+        if ([int]$observed.version -ne [int]$expected.version -or
+                [string]$observed.name -cne [string]$expected.name -or
+                [string]$observed.checksum -cne [string]$expected.checksum) {
+            throw "Desktop database upgrade rewrote historical migration v$($expected.version)"
+        }
+    }
+
+    $afterTables = @{}
+    foreach ($table in @($After.business_tables)) {
+        $name = [string]$table.name
+        if ($afterTables.ContainsKey($name)) {
+            throw "Desktop database upgrade snapshot contains a duplicate table: $name"
+        }
+        $afterTables[$name] = $table
+    }
+    foreach ($expected in @($Before.business_tables)) {
+        $name = [string]$expected.name
+        if (-not $afterTables.ContainsKey($name)) {
+            throw "Desktop database upgrade removed an existing business table: $name"
+        }
+        $observed = $afterTables[$name]
+        if ([long]$observed.row_count -ne [long]$expected.row_count -or
+                [string]$observed.content_sha256 -cne [string]$expected.content_sha256) {
+            throw "Desktop database upgrade changed existing business data in table: $name"
+        }
+    }
+
+    if ($null -eq $After.sentinel -or
+            [string]$After.sentinel.id -cne $SentinelID -or
+            [string]$After.sentinel.name -cne $SentinelName -or
+            [string]$After.sentinel.root_path -cne $SentinelRoot -or
+            [string]$After.sentinel.created_at_text -cne "sqlite-text:$SentinelCreatedAt") {
+        throw "Desktop database upgrade did not preserve the isolated Workspace sentinel"
+    }
+
+    $integrity = @($After.integrity_check)
+    if ($integrity.Count -ne 1 -or [string]$integrity[0] -cne "ok") {
+        throw "Desktop database integrity_check failed after upgrade: $($integrity -join ', ')"
+    }
+    if ([int]$After.foreign_key_violation_count -ne 0) {
+        throw "Desktop database has foreign-key violations after upgrade"
+    }
+
+    $observedTriggers = @{}
+    foreach ($trigger in @($After.triggers)) {
+        $observedTriggers[[string]$trigger.name] = $trigger.sql
+    }
+    foreach ($name in $ExpectedTriggerSQL.Keys) {
+        if (-not $observedTriggers.ContainsKey($name) -or
+                [string]::IsNullOrWhiteSpace([string]$observedTriggers[$name])) {
+            throw "Desktop database upgrade did not restore canonical trigger: $name"
+        }
+        $observedSQL = Normalize-TriggerSQL -SQL ([string]$observedTriggers[$name])
+        if ($observedSQL -cne [string]$ExpectedTriggerSQL[$name]) {
+            throw "Desktop database trigger differs from clean-install baseline: $name"
+        }
+    }
 }
 
 $repositoryRoot = [System.IO.Path]::GetFullPath((Split-Path -Parent $PSScriptRoot))
@@ -123,6 +459,7 @@ $seedDatabaseHash = $null
 $seedSchemaVersion = $null
 $latestSchemaVersion = $null
 $sqlitePython = $null
+$canonicalRepairTriggers = $null
 if (-not [string]::IsNullOrWhiteSpace($SeedDatabasePath)) {
     $seedDatabase = if ([System.IO.Path]::IsPathRooted($SeedDatabasePath)) {
         [System.IO.Path]::GetFullPath($SeedDatabasePath)
@@ -145,6 +482,7 @@ if (-not [string]::IsNullOrWhiteSpace($SeedDatabasePath)) {
     $seedDatabaseHash = (Get-FileHash -LiteralPath $seedDatabase -Algorithm SHA256).Hash
     $latestSchemaVersion = Read-LatestSchemaVersion -RepositoryRoot $repositoryRoot
     $sqlitePython = Find-SqlitePython
+    $canonicalRepairTriggers = Read-CanonicalRepairTriggers -RepositoryRoot $repositoryRoot
     $seedSchemaVersion = Read-DatabaseSchemaVersion -DatabasePath $seedDatabase `
         -PythonRuntime $sqlitePython -Description "seed database" -Immutable
     $seedDatabaseHashAfterRead = (Get-FileHash -LiteralPath $seedDatabase -Algorithm SHA256).Hash
@@ -160,18 +498,47 @@ $temporaryRoot = Join-Path $repositoryRoot ".tmp"
 $isolatedHome = Join-Path $temporaryRoot ("desktop-direct-launch-smoke-" + [guid]::NewGuid().ToString("N"))
 $database = Join-Path $isolatedHome "cyberagent.db"
 [System.IO.Directory]::CreateDirectory($isolatedHome) | Out-Null
+$sentinelToken = [guid]::NewGuid().ToString("N")
+$sentinelID = "desktop-seeded-smoke-$sentinelToken"
+$sentinelName = "Traverse Board seeded smoke $sentinelToken"
+$sentinelRoot = "C:\TraverseBoardSeededSmoke\$sentinelToken"
+$sentinelCreatedAt = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ",
+    [System.Globalization.CultureInfo]::InvariantCulture)
 $previousHome = $env:CYBERAGENT_HOME
 $process = $null
 $startedProcessID = $null
 $startupSucceeded = $false
 $observedSchemaVersion = $null
 $lastDatabaseProbeError = $null
+$seedUpgradeSnapshot = $null
 try {
     if ($null -ne $seedDatabase) {
         [System.IO.File]::Copy($seedDatabase, $database, $false)
         $copiedDatabaseHash = (Get-FileHash -LiteralPath $database -Algorithm SHA256).Hash
         if ($copiedDatabaseHash -cne $seedDatabaseHash) {
             throw "Isolated Desktop smoke database does not match the seed before launch"
+        }
+        Add-IsolatedWorkspaceSentinel -DatabasePath $database -PythonRuntime $sqlitePython `
+            -SentinelID $sentinelID -SentinelName $sentinelName -SentinelRoot $sentinelRoot `
+            -SentinelCreatedAt $sentinelCreatedAt
+        $seedUpgradeSnapshot = Read-DatabaseUpgradeSnapshot -DatabasePath $database `
+            -PythonRuntime $sqlitePython -SentinelID $sentinelID `
+            -Description "Capture isolated seed database preservation snapshot"
+        if ([int]$seedUpgradeSnapshot.schema_version -ne $seedSchemaVersion) {
+            throw "Isolated seed database schema changed before Desktop launch"
+        }
+        $seedIntegrity = @($seedUpgradeSnapshot.integrity_check)
+        if ($seedIntegrity.Count -ne 1 -or [string]$seedIntegrity[0] -cne "ok" -or
+                [int]$seedUpgradeSnapshot.foreign_key_violation_count -ne 0) {
+            throw "Desktop smoke seed database is not healthy before launch"
+        }
+        if ($null -eq $seedUpgradeSnapshot.sentinel -or
+                [string]$seedUpgradeSnapshot.sentinel.id -cne $sentinelID -or
+                [string]$seedUpgradeSnapshot.sentinel.name -cne $sentinelName -or
+                [string]$seedUpgradeSnapshot.sentinel.root_path -cne $sentinelRoot -or
+                [string]$seedUpgradeSnapshot.sentinel.created_at_text -cne
+                    "sqlite-text:$sentinelCreatedAt") {
+            throw "Isolated Workspace sentinel was not durable before Desktop launch"
         }
     }
     $env:CYBERAGENT_HOME = $isolatedHome
@@ -209,13 +576,15 @@ try {
                 throw "Desktop exited after creating its local store with code $($process.ExitCode)"
             }
             if ($null -ne $seedDatabase) {
-                $confirmedSchemaVersion = Read-DatabaseSchemaVersion -DatabasePath $database `
-                    -PythonRuntime $sqlitePython -Description "isolated database"
-                if ($confirmedSchemaVersion -ne $latestSchemaVersion -or
-                        $confirmedSchemaVersion -le $seedSchemaVersion) {
-                    throw "Desktop database upgrade was not stable: seed=v$seedSchemaVersion expected=v$latestSchemaVersion observed=v$confirmedSchemaVersion"
-                }
-                $observedSchemaVersion = $confirmedSchemaVersion
+                $upgradedSnapshot = Read-DatabaseUpgradeSnapshot -DatabasePath $database `
+                    -PythonRuntime $sqlitePython -SentinelID $sentinelID `
+                    -Description "Verify isolated upgraded database preservation"
+                Assert-SeededUpgradePreserved -Before $seedUpgradeSnapshot `
+                    -After $upgradedSnapshot -ExpectedSchemaVersion $latestSchemaVersion `
+                    -ExpectedTriggerSQL $canonicalRepairTriggers -SentinelID $sentinelID `
+                    -SentinelName $sentinelName -SentinelRoot $sentinelRoot `
+                    -SentinelCreatedAt $sentinelCreatedAt
+                $observedSchemaVersion = [int]$upgradedSnapshot.schema_version
             }
             $startupSucceeded = $true
             break
@@ -278,4 +647,7 @@ if ($null -ne $seedDatabase) {
     Write-Output "desktop_direct_launch_observed_schema_version: $observedSchemaVersion"
     Write-Output "desktop_direct_launch_expected_schema_version: $latestSchemaVersion"
     Write-Output "desktop_direct_launch_seed_source_unchanged: true"
+    Write-Output "desktop_direct_launch_existing_business_data_preserved: true"
+    Write-Output "desktop_direct_launch_historical_ledger_preserved: true"
+    Write-Output "desktop_direct_launch_repair_triggers_canonical: true"
 }


### PR DESCRIPTION
## Problem

The Windows prerelease `desktop-preview-20260828.1` rejects one exact intermediate v136 Desktop database with `FAILED_PRECONDITION`. The database is healthy; its v136 migration checksum predates two final Supervisor triggers.

## Fix

- accept only the pinned legacy v136 checksum under the canonical v136 name;
- add transactional v138 forward repair for the two missing Supervisor authority triggers;
- preserve the recorded v136 checksum and all application rows;
- keep every other version, name, checksum, gap, and unknown history fail-closed;
- add a seeded packaged-EXE smoke that requires a real old-to-current schema upgrade and proves the seed is unchanged;
- document the compatibility boundary in ADR 0146.

## Verification

- `go test ./internal/store -count=1 -timeout 20m`
- targeted v136/v137/v138, clean-install-baseline, and README migration tests
- `go test -race ./internal/store -run TestSchemaV138 -count=1`
- `go vet ./internal/store`
- real affected database copy: v136 -> v138; integrity check OK; zero FK violations; both canonical triggers restored; 1,259 pre-existing application rows unchanged; original v136 ledger checksum unchanged
- old `.1` EXE plus the legacy seed now fails the seeded smoke instead of being misreported as healthy

The actual user database was not modified during diagnosis or verification. A new `.2` prerelease will be built from the merged commit and tested against another isolated copy.

Refs #123